### PR TITLE
add pagination to delivery info endpoint

### DIFF
--- a/src/main/java/com/obj/nc/controllers/DeliveryInfoRestController.java
+++ b/src/main/java/com/obj/nc/controllers/DeliveryInfoRestController.java
@@ -22,6 +22,8 @@ package com.obj.nc.controllers;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.obj.nc.config.NcAppConfigProperties;
 import com.obj.nc.domain.content.MessageContent;
+import com.obj.nc.domain.dto.content.MessageContentDto;
+import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
 import com.obj.nc.domain.endpoints.ReceivingEndpoint;
 import com.obj.nc.domain.event.GenericEvent;
 import com.obj.nc.domain.message.Message;
@@ -96,8 +98,8 @@ public class DeliveryInfoRestController {
 					Optional<MessagePersistentState> msg = messages.stream().filter(it -> it.getId().equals(msgId)).findFirst();
 
 					return EndpointDeliveryInfoDto.builder()
-							.endpoint(ep.orElse(null))
-							.message(msg.map(MessagePersistentState::getBody).orElse(null))
+							.endpoint(ep.map(ReceivingEndpoint::toDto).orElse(null))
+							.message(msg.map(MessagePersistentState::getBody).map(MessageContent::toDto).orElse(null))
 							.currentStatus(delivery.getStatus())
 							.statusReachedAt(delivery.getProcessedOn())
 							.build();
@@ -163,7 +165,7 @@ public class DeliveryInfoRestController {
             .stream()
             .collect(Collectors.toMap(EndpointDeliveryInfoDto::getEndpointId, info->info));
 
-		endpoints.forEach(re-> endpointsById.get(re.getId()).setEndpoint(re));
+		endpoints.forEach(re-> endpointsById.get(re.getId()).setEndpoint(re.toDto()));
 
 		return infoDtos;
 	}
@@ -176,8 +178,8 @@ public class DeliveryInfoRestController {
 		@Transient
 		UUID endpointId;
 
-		MessageContent message;
-		ReceivingEndpoint endpoint;
+		MessageContentDto message;
+		ReceivingEndpointDto endpoint;
 		DELIVERY_STATUS currentStatus;
 		Instant statusReachedAt;
 

--- a/src/main/java/com/obj/nc/controllers/DeliveryInfoRestController.java
+++ b/src/main/java/com/obj/nc/controllers/DeliveryInfoRestController.java
@@ -21,10 +21,12 @@ package com.obj.nc.controllers;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.obj.nc.config.NcAppConfigProperties;
+import com.obj.nc.domain.content.MessageContent;
 import com.obj.nc.domain.endpoints.ReceivingEndpoint;
 import com.obj.nc.domain.event.GenericEvent;
 import com.obj.nc.domain.message.Message;
 import com.obj.nc.domain.message.MessagePersistentState;
+import com.obj.nc.domain.pagination.ResultPage;
 import com.obj.nc.flows.deliveryInfo.DeliveryInfoFlow;
 import com.obj.nc.functions.processors.deliveryInfo.domain.DeliveryInfo;
 import com.obj.nc.functions.processors.deliveryInfo.domain.DeliveryInfo.DELIVERY_STATUS;
@@ -35,9 +37,10 @@ import com.obj.nc.repositories.MessageRepository;
 import lombok.Builder;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.annotation.Transient;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -62,41 +65,62 @@ public class DeliveryInfoRestController {
 	@Autowired private NcAppConfigProperties ncAppConfigProperties;
 
 	@GetMapping(value = "/events/{eventId}", produces="application/json")
-    public List<EndpointDeliveryInfoDto> findDeliveryInfosByEventId(
-    		@PathVariable (value = "eventId", required = true) String eventId,
-			@RequestParam(value = "endpointId", required = false) String endpointId) {
-
+	public ResultPage<EndpointDeliveryInfoDto> findDeliveryInfosByEventId(
+			@PathVariable (value = "eventId", required = true) String eventId,
+			@RequestParam(value = "endpointId", required = false) String endpointId,
+			@PageableDefault(size = 20) Pageable pageable
+	) {
 		UUID endpointUUID = endpointId == null ? null : UUID.fromString(endpointId);
 
-		List<DeliveryInfo> deliveryInfos = deliveryRepo.findByEventIdAndEndpointIdOrderByProcessedOn(UUID.fromString(eventId), endpointUUID);
+		long total = deliveryRepo.countByEventIdAndEndpointId(UUID.fromString(eventId), endpointUUID);
+		List<DeliveryInfo> deliveries = deliveryRepo.findByEventIdAndEndpointIdOrderByProcessedOn(
+				UUID.fromString(eventId), endpointUUID, pageable.getPageSize(), pageable.getOffset());
 
-		if (deliveryInfos.isEmpty()) {
+		if (deliveries.isEmpty()) {
 			log.warn("Failed to map event {} to delivery info. This indicate problem with data - probably no message exists for event.", eventId);
-			return Collections.emptyList();
+			return new ResultPage<>(Collections.emptyList());
 		}
 
-		List<EndpointDeliveryInfoDto> infoDtos =  EndpointDeliveryInfoDto.createFrom(deliveryInfos);
+		UUID[] endpointIds = deliveries.stream().map(DeliveryInfo::getEndpointId).toArray(UUID[]::new);
+		List<UUID> messageIds = deliveries.stream().map(DeliveryInfo::getMessageId).collect(Collectors.toList());
 
-		List<UUID> endpointIds = infoDtos.stream().map(i -> i.getEndpointId()).collect(Collectors.toList());
-		List<ReceivingEndpoint> endpoints = endpointRepo.findByIds(endpointIds.toArray(new UUID[0]));
-		Map<UUID, EndpointDeliveryInfoDto> endpointsById = infoDtos.stream().collect(Collectors.toMap(EndpointDeliveryInfoDto::getEndpointId, info->info));
-		endpoints.forEach(re-> endpointsById.get(re.getId()).setEndpoint(re));
+		List<ReceivingEndpoint> endpoints = endpointRepo.findByIds(endpointIds);
+		List<MessagePersistentState> messages = messageRepo.findByIdIn(messageIds);
 
-		return infoDtos;
-    }
+		List<EndpointDeliveryInfoDto> result = deliveries.stream()
+				.map(delivery -> {
+					UUID epId = delivery.getEndpointId();
+					UUID msgId = delivery.getMessageId();
+
+					Optional<ReceivingEndpoint> ep = endpoints.stream().filter(it -> it.getId().equals(epId)).findFirst();
+					Optional<MessagePersistentState> msg = messages.stream().filter(it -> it.getId().equals(msgId)).findFirst();
+
+					return EndpointDeliveryInfoDto.builder()
+							.endpoint(ep.orElse(null))
+							.message(msg.map(MessagePersistentState::getBody).orElse(null))
+							.currentStatus(delivery.getStatus())
+							.statusReachedAt(delivery.getProcessedOn())
+							.build();
+				})
+				.collect(Collectors.toList());
+
+		return new ResultPage<>(result, pageable, total);
+	}
 
 	@GetMapping(value = "/events/ext/{extEventId}", produces="application/json")
-    public List<EndpointDeliveryInfoDto> findDeliveryInfosByExtId(
-    		@PathVariable (value = "extEventId", required = true) String extEventId,
-			@RequestParam(value = "endpointId", required = false) String endpointId) {
+	public ResultPage<EndpointDeliveryInfoDto> findDeliveryInfosByExtId(
+			@PathVariable (value = "extEventId", required = true) String extEventId,
+			@RequestParam(value = "endpointId", required = false) String endpointId,
+			@PageableDefault(size = 20) Pageable pageable
+	) {
 
 		GenericEvent event = eventRepo.findByExternalId(extEventId);
 		if (event == null) {
 			throw new IllegalArgumentException("Event with " +  extEventId +" external ID not found");
 		}
 
-		return findDeliveryInfosByEventId(event.getId().toString(), endpointId);
-    }
+		return findDeliveryInfosByEventId(event.getId().toString(), endpointId, pageable);
+	}
 
 	@GetMapping(value = "/messages/{messageId}/mark-as-read")
 	public ResponseEntity<Void> trackMessageRead(@PathVariable(value = "messageId", required = true) String messageId) {
@@ -152,8 +176,8 @@ public class DeliveryInfoRestController {
 		@Transient
 		UUID endpointId;
 
+		MessageContent message;
 		ReceivingEndpoint endpoint;
-
 		DELIVERY_STATUS currentStatus;
 		Instant statusReachedAt;
 

--- a/src/main/java/com/obj/nc/controllers/EndpointsRestController.java
+++ b/src/main/java/com/obj/nc/controllers/EndpointsRestController.java
@@ -22,6 +22,7 @@ package com.obj.nc.controllers;
 import com.obj.nc.domain.dto.EndpointTableViewDto;
 import com.obj.nc.domain.dto.EndpointTableViewDto.EndpointType;
 import com.obj.nc.domain.endpoints.ReceivingEndpoint;
+import com.obj.nc.domain.pagination.ResultPage;
 import com.obj.nc.repositories.EndpointsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -69,7 +70,7 @@ public class EndpointsRestController {
         
         long endpointsTotalCount = endpointsRepository.countAllEndpointsWithStats(processedFrom, processedTo, endpointType, eventId, endpointId);
         
-        return new PageImpl<>(endpoints, pageable, endpointsTotalCount);
+        return new ResultPage<>(endpoints, pageable, endpointsTotalCount);
     }
     
     @GetMapping(value = "/{endpointId}", produces = APPLICATION_JSON_VALUE)

--- a/src/main/java/com/obj/nc/controllers/EventsRestController.java
+++ b/src/main/java/com/obj/nc/controllers/EventsRestController.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.obj.nc.domain.dto.GenericEventTableViewDto;
 import com.obj.nc.domain.event.EventRecieverResponce;
 import com.obj.nc.domain.event.GenericEvent;
+import com.obj.nc.domain.pagination.ResultPage;
 import com.obj.nc.exceptions.PayloadValidationException;
 import com.obj.nc.functions.processors.eventValidator.GenericEventJsonSchemaValidator;
 import com.obj.nc.functions.processors.eventValidator.SimpleJsonValidator;
@@ -109,7 +110,7 @@ public class EventsRestController {
 				.collect(Collectors.toList());
 		
 		long eventsTotalCount = eventsRepository.countAllEventsWithStats(consumedFrom, consumedTo, eventUUID);
-		return new PageImpl<>(events, pageable, eventsTotalCount);
+		return new ResultPage<>(events, pageable, eventsTotalCount);
 	}
 	
 	@GetMapping(value = "/{eventId}", produces = APPLICATION_JSON_VALUE)

--- a/src/main/java/com/obj/nc/controllers/MessagesRestController.java
+++ b/src/main/java/com/obj/nc/controllers/MessagesRestController.java
@@ -24,6 +24,7 @@ import com.obj.nc.domain.dto.SendEmailMessageRequest;
 import com.obj.nc.domain.message.EmailMessage;
 import com.obj.nc.domain.message.MessagePersistentState;
 import com.obj.nc.domain.message.SendMessageResponse;
+import com.obj.nc.domain.pagination.ResultPage;
 import com.obj.nc.flows.messageProcessing.MessageProcessingFlow;
 import com.obj.nc.repositories.MessageRepository;
 import lombok.RequiredArgsConstructor;
@@ -77,7 +78,7 @@ public class MessagesRestController {
                 .findAllMessages(createdFrom, createdTo, eventUUID, pageable.getOffset(), pageable.getPageSize());
         
         long messagesTotalCount = messageRepository.countAllMessages(createdFrom, createdTo, eventUUID);
-        return new PageImpl<>(messages, pageable, messagesTotalCount);
+        return new ResultPage<>(messages, pageable, messagesTotalCount);
     }
     
     @GetMapping(value = "/{messageId}", produces = APPLICATION_JSON_VALUE)

--- a/src/main/java/com/obj/nc/domain/content/MessageContent.java
+++ b/src/main/java/com/obj/nc/domain/content/MessageContent.java
@@ -22,6 +22,7 @@ package com.obj.nc.domain.content;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.obj.nc.domain.BaseDynamicAttributesBean;
 import com.obj.nc.domain.content.email.EmailContent;
+import com.obj.nc.domain.dto.content.MessageContentDto;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -29,5 +30,5 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = false)
 public abstract class MessageContent extends BaseDynamicAttributesBean {
-	
+    public abstract MessageContentDto toDto();
 }

--- a/src/main/java/com/obj/nc/domain/content/TemplateWithModelContent.java
+++ b/src/main/java/com/obj/nc/domain/content/TemplateWithModelContent.java
@@ -21,11 +21,8 @@ package com.obj.nc.domain.content;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import com.obj.nc.domain.dto.content.TemplateWithModelContentDto;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,5 +41,9 @@ public class TemplateWithModelContent<MODEL_TYPE> extends MessageContent {
 	private MODEL_TYPE model;
 	
 	private List<Locale> requiredLocales = new ArrayList<>();
-	
+
+	@Override
+	public TemplateWithModelContentDto<MODEL_TYPE> toDto() {
+		return TemplateWithModelContentDto.create(this.templateFileName, this.model, this.requiredLocales);
+	}
 }

--- a/src/main/java/com/obj/nc/domain/content/email/EmailContent.java
+++ b/src/main/java/com/obj/nc/domain/content/email/EmailContent.java
@@ -22,11 +22,8 @@ package com.obj.nc.domain.content.email;
 import com.obj.nc.domain.Attachment;
 import com.obj.nc.domain.content.MessageContent;
 import com.obj.nc.domain.content.TrackableContent;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import com.obj.nc.domain.dto.content.EmailContentDto;
+import lombok.*;
 import org.springframework.http.MediaType;
 
 import java.util.ArrayList;
@@ -70,5 +67,9 @@ public class EmailContent extends MessageContent implements TrackableContent {
 	public void setHtmlText(String text) {
 		setText(text);
 	}
-	
+
+	@Override
+	public EmailContentDto toDto() {
+		return EmailContentDto.create(this.subject, this.text, this.contentType, this.attachments);
+	}
 }

--- a/src/main/java/com/obj/nc/domain/content/email/TemplateWithModelEmailContent.java
+++ b/src/main/java/com/obj/nc/domain/content/email/TemplateWithModelEmailContent.java
@@ -22,6 +22,8 @@ package com.obj.nc.domain.content.email;
 import com.obj.nc.Get;
 import com.obj.nc.domain.Attachment;
 import com.obj.nc.domain.content.TemplateWithModelContent;
+import com.obj.nc.domain.dto.content.TemplateWithModelContentDto;
+import com.obj.nc.domain.dto.content.TemplateWithModelEmailContentDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -62,5 +64,10 @@ public class TemplateWithModelEmailContent<MODEL_TYPE> extends TemplateWithModel
 		}
 		return subject;
 	}
-	
+
+	@Override
+	public TemplateWithModelEmailContentDto<MODEL_TYPE> toDto() {
+		return TemplateWithModelEmailContentDto.create(this.getTemplateFileName(), this.getModel(), this.getRequiredLocales(),
+				this.subjectResourceKey, this.subjectResourcesMessageParameters, this.subject, this.attachments);
+	}
 }

--- a/src/main/java/com/obj/nc/domain/content/mailchimp/BaseMailchimpContent.java
+++ b/src/main/java/com/obj/nc/domain/content/mailchimp/BaseMailchimpContent.java
@@ -36,7 +36,5 @@ import java.util.List;
 public abstract class BaseMailchimpContent extends MessageContent {
     
     private String subject;
-    
     private List<Attachment> attachments = new ArrayList<>();
-    
 }

--- a/src/main/java/com/obj/nc/domain/content/mailchimp/MailchimpContent.java
+++ b/src/main/java/com/obj/nc/domain/content/mailchimp/MailchimpContent.java
@@ -20,6 +20,8 @@
 package com.obj.nc.domain.content.mailchimp;
 
 import com.obj.nc.domain.content.TrackableContent;
+import com.obj.nc.domain.dto.content.MailchimpContentDto;
+import com.obj.nc.domain.dto.content.MessageContentDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -49,5 +51,9 @@ public class MailchimpContent extends BaseMailchimpContent implements TrackableC
     public void setHtmlText(String text) {
         setHtml(text);
     }
-    
+
+    @Override
+    public MessageContentDto toDto() {
+        return MailchimpContentDto.create(this.html, this.getSubject(), this.getAttachments());
+    }
 }

--- a/src/main/java/com/obj/nc/domain/content/mailchimp/TemplatedMailchimpContent.java
+++ b/src/main/java/com/obj/nc/domain/content/mailchimp/TemplatedMailchimpContent.java
@@ -19,11 +19,8 @@
 
 package com.obj.nc.domain.content.mailchimp;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import com.obj.nc.domain.dto.content.TemplatedMailchimpContentDto;
+import lombok.*;
 
 import java.util.Map;
 
@@ -41,5 +38,10 @@ public class TemplatedMailchimpContent extends BaseMailchimpContent {
     private String mergeLanguage;
     
     private Map<String, Object> mergeVariables;
-    
+
+    @Override
+    public TemplatedMailchimpContentDto toDto() {
+        return TemplatedMailchimpContentDto.create(this.templateName, this.templateContent, this.mergeLanguage,
+                this.mergeVariables, this.getSubject(), this.getAttachments());
+    }
 }

--- a/src/main/java/com/obj/nc/domain/content/push/PushContent.java
+++ b/src/main/java/com/obj/nc/domain/content/push/PushContent.java
@@ -20,11 +20,8 @@
 package com.obj.nc.domain.content.push;
 
 import com.obj.nc.domain.content.MessageContent;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import com.obj.nc.domain.dto.content.PushContentDto;
+import lombok.*;
 
 @Data
 @NoArgsConstructor
@@ -36,5 +33,10 @@ public class PushContent extends MessageContent {
     private String subject;
     private String text;
     private String iconUrl;
-    
+
+    @Override
+    public PushContentDto toDto() {
+        PushContentDto.create(this.subject, this.text, this.iconUrl);
+        return null;
+    }
 }

--- a/src/main/java/com/obj/nc/domain/content/push/PushContent.java
+++ b/src/main/java/com/obj/nc/domain/content/push/PushContent.java
@@ -36,7 +36,6 @@ public class PushContent extends MessageContent {
 
     @Override
     public PushContentDto toDto() {
-        PushContentDto.create(this.subject, this.text, this.iconUrl);
-        return null;
+        return PushContentDto.create(this.subject, this.text, this.iconUrl);
     }
 }

--- a/src/main/java/com/obj/nc/domain/content/slack/SlackMessageContent.java
+++ b/src/main/java/com/obj/nc/domain/content/slack/SlackMessageContent.java
@@ -20,6 +20,7 @@
 package com.obj.nc.domain.content.slack;
 
 import com.obj.nc.domain.content.MessageContent;
+import com.obj.nc.domain.dto.content.SlackMessageContentDto;
 import lombok.*;
 
 @Data
@@ -29,4 +30,9 @@ import lombok.*;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
 public class SlackMessageContent extends MessageContent {
     private String text;
+
+    @Override
+    public SlackMessageContentDto toDto() {
+        return SlackMessageContentDto.create(this.text);
+    }
 }

--- a/src/main/java/com/obj/nc/domain/content/sms/SimpleTextContent.java
+++ b/src/main/java/com/obj/nc/domain/content/sms/SimpleTextContent.java
@@ -20,6 +20,7 @@
 package com.obj.nc.domain.content.sms;
 
 import com.obj.nc.domain.content.MessageContent;
+import com.obj.nc.domain.dto.content.SmsContentDto;
 import lombok.*;
 
 @Data
@@ -32,4 +33,8 @@ public class SimpleTextContent extends MessageContent {
 	@EqualsAndHashCode.Include
 	private String text;
 
+	@Override
+	public SmsContentDto toDto() {
+		return SmsContentDto.create(this.text);
+	}
 }

--- a/src/main/java/com/obj/nc/domain/content/teams/TeamsMessageContent.java
+++ b/src/main/java/com/obj/nc/domain/content/teams/TeamsMessageContent.java
@@ -20,7 +20,11 @@
 package com.obj.nc.domain.content.teams;
 
 import com.obj.nc.domain.content.MessageContent;
-import lombok.*;
+import com.obj.nc.domain.dto.content.TeamsMessageContentDto;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
 
 @Getter
 @Builder
@@ -28,4 +32,9 @@ import lombok.*;
 public class TeamsMessageContent extends MessageContent {
     @NonNull
     private String text;
+
+    @Override
+    public TeamsMessageContentDto toDto() {
+        return TeamsMessageContentDto.create(this.text);
+    }
 }

--- a/src/main/java/com/obj/nc/domain/dto/content/BaseMailchimpContentDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/content/BaseMailchimpContentDto.java
@@ -1,0 +1,16 @@
+package com.obj.nc.domain.dto.content;
+
+import com.obj.nc.domain.Attachment;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
+public abstract class BaseMailchimpContentDto extends MessageContentDto {
+
+    private String subject;
+    private List<Attachment> attachments = new ArrayList<>();
+}

--- a/src/main/java/com/obj/nc/domain/dto/content/EmailContentDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/content/EmailContentDto.java
@@ -1,0 +1,38 @@
+package com.obj.nc.domain.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.obj.nc.domain.Attachment;
+import com.obj.nc.domain.dto.endpoint.EmailEndpointDto;
+import com.obj.nc.domain.dto.endpoint.SmsEndpointDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.springframework.http.MediaType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+@JsonTypeName("EMAIL")
+public class EmailContentDto extends MessageContentDto {
+
+    public static final String JSON_TYPE_IDENTIFIER = "EMAIL";
+    private String subject;
+    private String text;
+    private String contentType = MediaType.TEXT_PLAIN_VALUE;
+    private List<Attachment> attachments = new ArrayList<>();
+
+    public static EmailContentDto create(String subject, String text, String contentType, List<Attachment> attachments) {
+        EmailContentDto dto = new EmailContentDto();
+        dto.setSubject(subject);
+        dto.setText(text);
+        dto.setContentType(contentType);
+        dto.setAttachments(attachments);
+        return dto;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/content/MailchimpContentDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/content/MailchimpContentDto.java
@@ -1,0 +1,28 @@
+package com.obj.nc.domain.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.obj.nc.domain.Attachment;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, of = "html")
+@JsonTypeName("MAILCHIMP")
+public class MailchimpContentDto extends BaseMailchimpContentDto {
+
+    private String html;
+
+    public static MailchimpContentDto create(String html, String subject, List<Attachment> attachments) {
+        MailchimpContentDto dto = new MailchimpContentDto();
+        dto.setHtml(html);
+        dto.setSubject(subject);
+        dto.setAttachments(attachments);
+        return dto;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/content/MessageContentDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/content/MessageContentDto.java
@@ -1,0 +1,14 @@
+package com.obj.nc.domain.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Data;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = EmailContentDto.class, name = EmailContentDto.JSON_TYPE_IDENTIFIER),
+        @JsonSubTypes.Type(value = SmsContentDto.class, name = SmsContentDto.JSON_TYPE_IDENTIFIER),
+})
+@Data
+public abstract class MessageContentDto {
+}

--- a/src/main/java/com/obj/nc/domain/dto/content/PushContentDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/content/PushContentDto.java
@@ -1,0 +1,26 @@
+package com.obj.nc.domain.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, of = "text")
+@JsonTypeName("PUSH")
+public class PushContentDto extends MessageContentDto {
+    private String subject;
+    private String text;
+    private String iconUrl;
+
+    public static PushContentDto create(String subject, String text, String iconUrl) {
+        PushContentDto dto = new PushContentDto();
+        dto.setSubject(subject);
+        dto.setText(text);
+        dto.setIconUrl(iconUrl);
+        return dto;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/content/SlackMessageContentDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/content/SlackMessageContentDto.java
@@ -1,0 +1,23 @@
+package com.obj.nc.domain.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, of = "text")
+@JsonTypeName("SLACK")
+public class SlackMessageContentDto extends MessageContentDto {
+    public static final String JSON_TYPE_IDENTIFIER = "SLACK";
+    private String text;
+
+    public static SlackMessageContentDto create(String text) {
+        SlackMessageContentDto dto = new SlackMessageContentDto();
+        dto.setText(text);
+        return dto;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/content/SmsContentDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/content/SmsContentDto.java
@@ -1,0 +1,24 @@
+package com.obj.nc.domain.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, of = "text")
+@JsonTypeName("SMS")
+public class SmsContentDto extends MessageContentDto {
+
+    public static final String JSON_TYPE_IDENTIFIER = "SMS";
+    private String text;
+
+    public static SmsContentDto create(String text) {
+        SmsContentDto dto = new SmsContentDto();
+        dto.setText(text);
+        return dto;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/content/TeamsMessageContentDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/content/TeamsMessageContentDto.java
@@ -1,0 +1,23 @@
+package com.obj.nc.domain.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, of = "text")
+@JsonTypeName("TEAMS")
+public class TeamsMessageContentDto extends MessageContentDto {
+    public static final String JSON_TYPE_IDENTIFIER = "TEAMS";
+    private String text;
+
+    public static TeamsMessageContentDto create(String text) {
+        TeamsMessageContentDto dto = new TeamsMessageContentDto();
+        dto.setText(text);
+        return dto;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/content/TemplateWithModelContentDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/content/TemplateWithModelContentDto.java
@@ -1,0 +1,28 @@
+package com.obj.nc.domain.dto.content;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class TemplateWithModelContentDto<MODEL_TYPE> extends MessageContentDto {
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+    private MODEL_TYPE model;
+    private String templateFileName;
+    private List<Locale> requiredLocales = new ArrayList<>();
+
+    public static <MODEL_TYPE> TemplateWithModelContentDto<MODEL_TYPE> create(
+            String templateFileName, MODEL_TYPE model, List<Locale> requiredLocales) {
+        TemplateWithModelContentDto<MODEL_TYPE> dto = new TemplateWithModelContentDto<>();
+        dto.setTemplateFileName(templateFileName);
+        dto.setModel(model);
+        dto.setRequiredLocales(requiredLocales);
+        return dto;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/content/TemplateWithModelEmailContentDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/content/TemplateWithModelEmailContentDto.java
@@ -1,0 +1,33 @@
+package com.obj.nc.domain.dto.content;
+
+import com.obj.nc.domain.Attachment;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class TemplateWithModelEmailContentDto<MODEL_TYPE> extends TemplateWithModelContentDto<MODEL_TYPE> {
+
+    private String subjectResourceKey;
+    private String[] subjectResourcesMessageParameters;
+    private String subject;
+    private List<Attachment> attachments = new ArrayList<>();
+
+    public static <MODEL_TYPE> TemplateWithModelEmailContentDto<MODEL_TYPE> create(
+            String templateFileName, MODEL_TYPE model, List<Locale> requiredLocales, String subjectResourceKey,
+            String[] subjectResourcesMessageParameters, String subject, List<Attachment> attachments) {
+        TemplateWithModelEmailContentDto<MODEL_TYPE> dto = new TemplateWithModelEmailContentDto<>();
+        dto.setTemplateFileName(templateFileName);
+        dto.setModel(model);
+        dto.setRequiredLocales(requiredLocales);
+        dto.setSubjectResourceKey(subjectResourceKey);
+        dto.setSubjectResourcesMessageParameters(subjectResourcesMessageParameters);
+        dto.setSubject(subject);
+        dto.setAttachments(attachments);
+        return dto;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/content/TemplatedMailchimpContentDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/content/TemplatedMailchimpContentDto.java
@@ -1,0 +1,31 @@
+package com.obj.nc.domain.dto.content;
+
+import com.obj.nc.domain.Attachment;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false)
+public class TemplatedMailchimpContentDto extends BaseMailchimpContentDto {
+
+    private String templateName;
+    private Map<String, String> templateContent;
+    private String mergeLanguage;
+    private Map<String, Object> mergeVariables;
+
+    public static TemplatedMailchimpContentDto create(
+            String templateName, Map<String, String> templateContent, String mergeLanguage, Map<String,
+            Object> mergeVariables, String subject, List<Attachment> attachments) {
+        TemplatedMailchimpContentDto dto = new TemplatedMailchimpContentDto();
+        dto.setTemplateName(templateName);
+        dto.setTemplateContent(templateContent);
+        dto.setMergeLanguage(mergeLanguage);
+        dto.setMergeVariables(mergeVariables);
+        dto.setSubject(subject);
+        dto.setAttachments(attachments);
+        return dto;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/endpoint/DirectPushEndpointDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/endpoint/DirectPushEndpointDto.java
@@ -1,0 +1,36 @@
+package com.obj.nc.domain.dto.endpoint;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, of = "token")
+@JsonTypeName("DIRECT_PUSH")
+public class DirectPushEndpointDto extends ReceivingEndpointDto {
+
+    public static final String JSON_TYPE_IDENTIFIER = "DIRECT_PUSH";
+
+    private String token;
+
+    public static DirectPushEndpointDto create(String id, String token) {
+        DirectPushEndpointDto dto = new DirectPushEndpointDto();
+        dto.setId(id);
+        dto.setToken(token);
+        return dto;
+    }
+
+    @Override
+    public String getValue() {
+        return this.token;
+    }
+
+    @Override
+    public void setValue(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/endpoint/EmailEndpointDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/endpoint/EmailEndpointDto.java
@@ -1,0 +1,35 @@
+package com.obj.nc.domain.dto.endpoint;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, of = "email")
+@JsonTypeName("Email")
+public class EmailEndpointDto extends ReceivingEndpointDto {
+
+    public static final String JSON_TYPE_IDENTIFIER = "EMAIL";
+    private String email;
+
+    public static EmailEndpointDto create(String id, String email) {
+        EmailEndpointDto dto = new EmailEndpointDto();
+        dto.setId(id);
+        dto.setEmail(email);
+        return dto;
+    }
+
+    @Override
+    public String getValue() {
+        return this.email;
+    }
+
+    @Override
+    public void setValue(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/endpoint/MailchimpEndpointDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/endpoint/MailchimpEndpointDto.java
@@ -1,0 +1,36 @@
+package com.obj.nc.domain.dto.endpoint;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, of = "email")
+@JsonTypeName("MAILCHIMP")
+public class MailchimpEndpointDto extends ReceivingEndpointDto {
+
+    public static final String JSON_TYPE_IDENTIFIER = "MAILCHIMP";
+
+    private String email;
+
+    public static MailchimpEndpointDto create(String id, String email) {
+        MailchimpEndpointDto dto = new MailchimpEndpointDto();
+        dto.setId(id);
+        dto.setEmail(email);
+        return dto;
+    }
+
+    @Override
+    public String getValue() {
+        return this.email;
+    }
+
+    @Override
+    public void setValue(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/endpoint/ReceivingEndpointDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/endpoint/ReceivingEndpointDto.java
@@ -1,0 +1,21 @@
+package com.obj.nc.domain.dto.endpoint;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Data;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = EmailEndpointDto.class, name = EmailEndpointDto.JSON_TYPE_IDENTIFIER),
+        @JsonSubTypes.Type(value = MailchimpEndpointDto.class, name = MailchimpEndpointDto.JSON_TYPE_IDENTIFIER),
+        @JsonSubTypes.Type(value = SmsEndpointDto.class, name = SmsEndpointDto.JSON_TYPE_IDENTIFIER),
+        @JsonSubTypes.Type(value = DirectPushEndpointDto.class, name = DirectPushEndpointDto.JSON_TYPE_IDENTIFIER),
+        @JsonSubTypes.Type(value = TopicPushEndpointDto.class, name = TopicPushEndpointDto.JSON_TYPE_IDENTIFIER)
+})
+@Data
+public abstract class ReceivingEndpointDto {
+    private String id;
+
+    public abstract String getValue();
+    public abstract void setValue(String value);
+}

--- a/src/main/java/com/obj/nc/domain/dto/endpoint/SlackEndpointDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/endpoint/SlackEndpointDto.java
@@ -1,0 +1,36 @@
+package com.obj.nc.domain.dto.endpoint;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.obj.nc.domain.endpoints.SlackEndpoint;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, of = "channel")
+@JsonTypeName("SLACK")
+public class SlackEndpointDto extends ReceivingEndpointDto {
+
+    public static final String JSON_TYPE_IDENTIFIER = "SLACK";
+    private String channel;
+
+    public static SlackEndpointDto create(String id, String channel) {
+        SlackEndpointDto dto = new SlackEndpointDto();
+        dto.setId(id);
+        dto.setChannel(channel);
+        return dto;
+    }
+
+    @Override
+    public String getValue() {
+        return this.channel;
+    }
+
+    @Override
+    public void setValue(String channel) {
+        this.channel = channel;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/endpoint/SmsEndpointDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/endpoint/SmsEndpointDto.java
@@ -1,0 +1,35 @@
+package com.obj.nc.domain.dto.endpoint;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, of = "phone")
+@JsonTypeName("SMS")
+public class SmsEndpointDto extends ReceivingEndpointDto {
+
+    public static final String JSON_TYPE_IDENTIFIER = "SMS";
+    private String phone;
+
+    public static SmsEndpointDto create(String id, String phone) {
+        SmsEndpointDto dto = new SmsEndpointDto();
+        dto.setId(id);
+        dto.setPhone(phone);
+        return dto;
+    }
+
+    @Override
+    public String getValue() {
+        return this.phone;
+    }
+
+    @Override
+    public void setValue(String phone) {
+        this.phone = phone;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/endpoint/TeamsEndpointDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/endpoint/TeamsEndpointDto.java
@@ -1,0 +1,35 @@
+package com.obj.nc.domain.dto.endpoint;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, of = "webhookUrl")
+@JsonTypeName("TEAMS")
+public class TeamsEndpointDto extends ReceivingEndpointDto {
+
+    public static final String JSON_TYPE_IDENTIFIER = "TEAMS";
+    private String webhookUrl;
+
+    public static TeamsEndpointDto create(String id, String webhookUrl) {
+        TeamsEndpointDto dto = new TeamsEndpointDto();
+        dto.setId(id);
+        dto.setWebhookUrl(webhookUrl);
+        return dto;
+    }
+
+    @Override
+    public String getValue() {
+        return this.webhookUrl;
+    }
+
+    @Override
+    public void setValue(String webhookUrl) {
+        this.webhookUrl = webhookUrl;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/dto/endpoint/TopicPushEndpointDto.java
+++ b/src/main/java/com/obj/nc/domain/dto/endpoint/TopicPushEndpointDto.java
@@ -1,0 +1,36 @@
+package com.obj.nc.domain.dto.endpoint;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = false, of = "topic")
+@JsonTypeName("TOPIC_PUSH")
+public class TopicPushEndpointDto extends ReceivingEndpointDto {
+
+    public static final String JSON_TYPE_IDENTIFIER = "TOPIC_PUSH";
+
+    private String topic;
+
+    public static TopicPushEndpointDto create(String id, String topic) {
+        TopicPushEndpointDto dto = new TopicPushEndpointDto();
+        dto.setId(id);
+        dto.setTopic(topic);
+        return dto;
+    }
+
+    @Override
+    public String getValue() {
+        return this.topic;
+    }
+
+    @Override
+    public void setValue(String topic) {
+        this.topic = topic;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/endpoints/EmailEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/EmailEndpoint.java
@@ -20,6 +20,8 @@
 package com.obj.nc.domain.endpoints;
 
 import com.google.common.collect.ObjectArrays;
+import com.obj.nc.domain.dto.endpoint.EmailEndpointDto;
+import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
 import com.obj.nc.domain.recipients.Group;
 import com.obj.nc.domain.recipients.Person;
 
@@ -76,6 +78,11 @@ public class EmailEndpoint extends ReceivingEndpoint {
 	@Override
 	public String getEndpointType() {
 		return JSON_TYPE_IDENTIFIER;
+	}
+
+	@Override
+	public ReceivingEndpointDto toDto() {
+		return EmailEndpointDto.create(this.getId().toString(), this.email);
 	}
 
 	public static FieldDescriptor[] fieldDesc = ObjectArrays.concat(

--- a/src/main/java/com/obj/nc/domain/endpoints/MailchimpEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/MailchimpEndpoint.java
@@ -19,13 +19,8 @@
 
 package com.obj.nc.domain.endpoints;
 
-import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
-import lombok.Builder;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import com.obj.nc.domain.dto.endpoint.MailchimpEndpointDto;
+import lombok.*;
 
 @Data
 @EqualsAndHashCode(callSuper=false)
@@ -56,8 +51,8 @@ public class MailchimpEndpoint extends ReceivingEndpoint {
     }
 
     @Override
-    public ReceivingEndpointDto toDto() {
-        return null;
+    public MailchimpEndpointDto toDto() {
+        return MailchimpEndpointDto.create(this.getId().toString(), this.getEmail());
     }
 
 }

--- a/src/main/java/com/obj/nc/domain/endpoints/MailchimpEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/MailchimpEndpoint.java
@@ -19,6 +19,7 @@
 
 package com.obj.nc.domain.endpoints;
 
+import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -53,5 +54,10 @@ public class MailchimpEndpoint extends ReceivingEndpoint {
     public String getEndpointType() {
         return JSON_TYPE_IDENTIFIER;
     }
-    
+
+    @Override
+    public ReceivingEndpointDto toDto() {
+        return null;
+    }
+
 }

--- a/src/main/java/com/obj/nc/domain/endpoints/ReceivingEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/ReceivingEndpoint.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
 import com.obj.nc.domain.endpoints.push.DirectPushEndpoint;
 import com.obj.nc.domain.endpoints.push.TopicPushEndpoint;
 import com.obj.nc.domain.recipients.Recipient;
@@ -70,6 +71,8 @@ public abstract class ReceivingEndpoint implements Persistable<UUID> {
 	
 	@JsonIgnore
 	public abstract String getEndpointType();
+
+	public abstract ReceivingEndpointDto toDto();
 
 	@Override
 	@JsonIgnore

--- a/src/main/java/com/obj/nc/domain/endpoints/SlackEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/SlackEndpoint.java
@@ -19,6 +19,7 @@
 
 package com.obj.nc.domain.endpoints;
 
+import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.ToString;
@@ -44,6 +45,11 @@ public class SlackEndpoint extends ReceivingEndpoint {
     @Override
     public String getEndpointType() {
         return JSON_TYPE_IDENTIFIER;
+    }
+
+    @Override
+    public ReceivingEndpointDto toDto() {
+        return null;
     }
 
 }

--- a/src/main/java/com/obj/nc/domain/endpoints/SlackEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/SlackEndpoint.java
@@ -19,7 +19,7 @@
 
 package com.obj.nc.domain.endpoints;
 
-import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
+import com.obj.nc.domain.dto.endpoint.SlackEndpointDto;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.ToString;
@@ -48,8 +48,8 @@ public class SlackEndpoint extends ReceivingEndpoint {
     }
 
     @Override
-    public ReceivingEndpointDto toDto() {
-        return null;
+    public SlackEndpointDto toDto() {
+        return SlackEndpointDto.create(this.getId().toString(), this.channel);
     }
 
 }

--- a/src/main/java/com/obj/nc/domain/endpoints/SmsEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/SmsEndpoint.java
@@ -21,6 +21,8 @@ package com.obj.nc.domain.endpoints;
 
 import javax.validation.constraints.NotNull;
 
+import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
+import com.obj.nc.domain.dto.endpoint.SmsEndpointDto;
 import com.obj.nc.domain.recipients.Person;
 
 import lombok.AllArgsConstructor;
@@ -60,6 +62,11 @@ public class SmsEndpoint extends ReceivingEndpoint {
     @Override
     public String getEndpointType() {
         return JSON_TYPE_IDENTIFIER;
+    }
+
+    @Override
+    public ReceivingEndpointDto toDto() {
+        return SmsEndpointDto.create(this.getId().toString(), this.phone);
     }
 
 }

--- a/src/main/java/com/obj/nc/domain/endpoints/TeamsEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/TeamsEndpoint.java
@@ -19,7 +19,7 @@
 
 package com.obj.nc.domain.endpoints;
 
-import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
+import com.obj.nc.domain.dto.endpoint.TeamsEndpointDto;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.ToString;
@@ -48,8 +48,8 @@ public class TeamsEndpoint extends ReceivingEndpoint {
     }
 
     @Override
-    public ReceivingEndpointDto toDto() {
-        return null;
+    public TeamsEndpointDto toDto() {
+        return TeamsEndpointDto.create(this.getId().toString(), this.webhookUrl);
     }
 
 }

--- a/src/main/java/com/obj/nc/domain/endpoints/TeamsEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/TeamsEndpoint.java
@@ -19,6 +19,7 @@
 
 package com.obj.nc.domain.endpoints;
 
+import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.ToString;
@@ -44,6 +45,11 @@ public class TeamsEndpoint extends ReceivingEndpoint {
     @Override
     public String getEndpointType() {
         return JSON_TYPE_IDENTIFIER;
+    }
+
+    @Override
+    public ReceivingEndpointDto toDto() {
+        return null;
     }
 
 }

--- a/src/main/java/com/obj/nc/domain/endpoints/push/DirectPushEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/push/DirectPushEndpoint.java
@@ -20,6 +20,7 @@
 package com.obj.nc.domain.endpoints.push;
 
 import com.google.firebase.messaging.Message;
+import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -54,5 +55,10 @@ public class DirectPushEndpoint extends PushEndpoint {
     public String getEndpointType() {
         return JSON_TYPE_IDENTIFIER;
     }
-    
+
+    @Override
+    public ReceivingEndpointDto toDto() {
+        return null;
+    }
+
 }

--- a/src/main/java/com/obj/nc/domain/endpoints/push/DirectPushEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/push/DirectPushEndpoint.java
@@ -20,7 +20,7 @@
 package com.obj.nc.domain.endpoints.push;
 
 import com.google.firebase.messaging.Message;
-import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
+import com.obj.nc.domain.dto.endpoint.DirectPushEndpointDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -57,8 +57,8 @@ public class DirectPushEndpoint extends PushEndpoint {
     }
 
     @Override
-    public ReceivingEndpointDto toDto() {
-        return null;
+    public DirectPushEndpointDto toDto() {
+        return DirectPushEndpointDto.create(this.getId().toString(), this.token);
     }
 
 }

--- a/src/main/java/com/obj/nc/domain/endpoints/push/TopicPushEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/push/TopicPushEndpoint.java
@@ -20,7 +20,7 @@
 package com.obj.nc.domain.endpoints.push;
 
 import com.google.firebase.messaging.Message;
-import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
+import com.obj.nc.domain.dto.endpoint.TopicPushEndpointDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -57,8 +57,8 @@ public class TopicPushEndpoint extends PushEndpoint {
     }
 
     @Override
-    public ReceivingEndpointDto toDto() {
-        return null;
+    public TopicPushEndpointDto toDto() {
+        return TopicPushEndpointDto.create(this.getId().toString(), this.topic);
     }
 
 }

--- a/src/main/java/com/obj/nc/domain/endpoints/push/TopicPushEndpoint.java
+++ b/src/main/java/com/obj/nc/domain/endpoints/push/TopicPushEndpoint.java
@@ -20,6 +20,7 @@
 package com.obj.nc.domain.endpoints.push;
 
 import com.google.firebase.messaging.Message;
+import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -54,5 +55,10 @@ public class TopicPushEndpoint extends PushEndpoint {
     public String getEndpointType() {
         return JSON_TYPE_IDENTIFIER;
     }
-    
+
+    @Override
+    public ReceivingEndpointDto toDto() {
+        return null;
+    }
+
 }

--- a/src/main/java/com/obj/nc/domain/pagination/ResultPage.java
+++ b/src/main/java/com/obj/nc/domain/pagination/ResultPage.java
@@ -1,0 +1,67 @@
+package com.obj.nc.domain.pagination;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@JsonAutoDetect(
+        fieldVisibility = Visibility.NONE,
+        setterVisibility = Visibility.NONE,
+        getterVisibility = Visibility.NONE,
+        isGetterVisibility = Visibility.NONE,
+        creatorVisibility = Visibility.NONE
+)
+public class ResultPage<T> extends PageImpl<T> {
+
+    public ResultPage(List<T> content, Pageable pageable, long total) {
+        super(content, pageable, total);
+    }
+
+    public ResultPage(List<T> content) {
+        super(content);
+    }
+
+    @JsonProperty
+    public List<T> getData() {
+        return super.getContent();
+    }
+
+    @JsonProperty
+    public boolean getNext() {
+        return !super.isLast();
+    }
+
+    @JsonProperty
+    public boolean getPrev() {
+        return !super.isFirst();
+    }
+
+    @JsonProperty
+    public boolean isEmpty() {
+        return super.isEmpty();
+    }
+
+    @JsonProperty
+    public int getTotalPages() {
+        return super.getTotalPages();
+    }
+
+    @JsonProperty
+    public long getTotalElements() {
+        return super.getTotalElements();
+    }
+
+    @JsonProperty
+    public int getSize() {
+        return super.getSize();
+    }
+
+    @JsonProperty
+    public int getPage() {
+        return super.getNumber() + 1;
+    }
+}

--- a/src/main/java/com/obj/nc/domain/pagination/ResultPage.java
+++ b/src/main/java/com/obj/nc/domain/pagination/ResultPage.java
@@ -26,7 +26,7 @@ public class ResultPage<T> extends PageImpl<T> {
     }
 
     @JsonProperty
-    public List<T> getData() {
+    public List<T> getContent() {
         return super.getContent();
     }
 

--- a/src/main/java/com/obj/nc/repositories/DeliveryInfoRepository.java
+++ b/src/main/java/com/obj/nc/repositories/DeliveryInfoRepository.java
@@ -73,7 +73,7 @@ public interface DeliveryInfoRepository extends PagingAndSortingRepository<Deliv
     List<DeliveryInfo> findByEventIdAndEndpointIdOrderByProcessedOn(@Param("eventId") UUID eventId,
                                                                     @Param("endpointId") UUID endpointId);
 
-    String QRY_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID = "WITH temp AS (\n" +
+    String QRY_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID = "WITH deliveries_partitioned_by_endpoint_id AS (\n" +
             "    SELECT di.*,\n" +
             "           dense_rank() OVER (PARTITION BY di.endpoint_id ORDER BY di.processed_on DESC) rnk\n" +
             "    FROM nc_delivery_info di\n" +
@@ -82,7 +82,7 @@ public interface DeliveryInfoRepository extends PagingAndSortingRepository<Deliv
             "      and ((:endpointId)::uuid is null or di.endpoint_id = (:endpointId)::uuid)\n" +
             ")\n" +
             "SELECT id, status, processed_on, version, failed_payload_id, message_id, endpoint_id\n" +
-            "FROM temp\n" +
+            "FROM deliveries_partitioned_by_endpoint_id\n" +
             "WHERE rnk = 1\n" +
             "limit :size offset :offset";
 
@@ -93,7 +93,7 @@ public interface DeliveryInfoRepository extends PagingAndSortingRepository<Deliv
                                                                     @Param("offset") long offset);
 
 
-    String QRY_COUNT_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID = "WITH temp AS (\n" +
+    String QRY_COUNT_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID = "WITH deliveries_partitioned_by_endpoint_id AS (\n" +
             "    SELECT di.*,\n" +
             "           dense_rank() OVER (PARTITION BY di.endpoint_id ORDER BY di.processed_on DESC) rnk\n" +
             "    FROM nc_delivery_info di\n" +
@@ -102,7 +102,7 @@ public interface DeliveryInfoRepository extends PagingAndSortingRepository<Deliv
             "      and ((:endpointId)::uuid is null or di.endpoint_id = (:endpointId)::uuid)\n" +
             ")\n" +
             "SELECT count(*)\n" +
-            "FROM temp\n" +
+            "FROM deliveries_partitioned_by_endpoint_id\n" +
             "WHERE rnk = 1\n";
 
     @Query(QRY_COUNT_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID)

--- a/src/main/java/com/obj/nc/repositories/DeliveryInfoRepository.java
+++ b/src/main/java/com/obj/nc/repositories/DeliveryInfoRepository.java
@@ -22,14 +22,14 @@ package com.obj.nc.repositories;
 import com.obj.nc.functions.processors.deliveryInfo.domain.DeliveryInfo;
 import com.obj.nc.functions.processors.deliveryInfo.domain.DeliveryInfo.DELIVERY_STATUS;
 import org.springframework.data.jdbc.repository.query.Query;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-public interface DeliveryInfoRepository extends CrudRepository<DeliveryInfo, UUID> {
+public interface DeliveryInfoRepository extends PagingAndSortingRepository<DeliveryInfo, UUID> {
 
     @Query("select di.* " +
             "from nc_delivery_info di " +
@@ -72,6 +72,42 @@ public interface DeliveryInfoRepository extends CrudRepository<DeliveryInfo, UUI
             "order by processed_on")
     List<DeliveryInfo> findByEventIdAndEndpointIdOrderByProcessedOn(@Param("eventId") UUID eventId,
                                                                     @Param("endpointId") UUID endpointId);
+
+    String QRY_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID = "WITH temp AS (\n" +
+            "    SELECT di.*,\n" +
+            "           dense_rank() OVER (PARTITION BY di.endpoint_id ORDER BY di.processed_on DESC) rnk\n" +
+            "    FROM nc_delivery_info di\n" +
+            "             join nc_message m on di.message_id = m.id\n" +
+            "    where :eventId = ANY (m.previous_event_ids)\n" +
+            "      and ((:endpointId)::uuid is null or di.endpoint_id = (:endpointId)::uuid)\n" +
+            ")\n" +
+            "SELECT id, status, processed_on, version, failed_payload_id, message_id, endpoint_id\n" +
+            "FROM temp\n" +
+            "WHERE rnk = 1\n" +
+            "limit :size offset :offset";
+
+    @Query(QRY_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID)
+    List<DeliveryInfo> findByEventIdAndEndpointIdOrderByProcessedOn(@Param("eventId") UUID eventId,
+                                                                    @Param("endpointId") UUID endpointId,
+                                                                    @Param("size") int size,
+                                                                    @Param("offset") long offset);
+
+
+    String QRY_COUNT_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID = "WITH temp AS (\n" +
+            "    SELECT di.*,\n" +
+            "           dense_rank() OVER (PARTITION BY di.endpoint_id ORDER BY di.processed_on DESC) rnk\n" +
+            "    FROM nc_delivery_info di\n" +
+            "             join nc_message m on di.message_id = m.id\n" +
+            "    where :eventId = ANY (m.previous_event_ids)\n" +
+            "      and ((:endpointId)::uuid is null or di.endpoint_id = (:endpointId)::uuid)\n" +
+            ")\n" +
+            "SELECT count(*)\n" +
+            "FROM temp\n" +
+            "WHERE rnk = 1\n";
+
+    @Query(QRY_COUNT_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID)
+    long countByEventIdAndEndpointId(@Param("eventId") UUID eventId, @Param("endpointId") UUID endpointId);
+
 
     List<DeliveryInfo> findByEndpointIdOrderByProcessedOn(UUID endpointId);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,3 +33,5 @@ nc.jwt.enabled=false
 
 server.port=${nc.app.url.port}
 server.servlet.context-path=${nc.app.url.context-path}
+
+spring.data.web.pageable.one-indexed-parameters=true

--- a/src/test/java/com/obj/nc/controllers/DeliveryInfoControllerTest.java
+++ b/src/test/java/com/obj/nc/controllers/DeliveryInfoControllerTest.java
@@ -27,6 +27,8 @@ import com.obj.nc.config.NcAppConfigProperties;
 import com.obj.nc.controllers.DeliveryInfoRestController.EndpointDeliveryInfoDto;
 import com.obj.nc.domain.content.email.EmailContent;
 import com.obj.nc.domain.content.sms.SimpleTextContent;
+import com.obj.nc.domain.dto.endpoint.EmailEndpointDto;
+import com.obj.nc.domain.dto.endpoint.SmsEndpointDto;
 import com.obj.nc.domain.endpoints.EmailEndpoint;
 import com.obj.nc.domain.endpoints.ReceivingEndpoint;
 import com.obj.nc.domain.endpoints.SmsEndpoint;
@@ -157,17 +159,17 @@ class DeliveryInfoControllerTest extends BaseIntegrationTest {
 
 		//THEN
 		Assertions.assertThat(infos.getContent().size()).isEqualTo(2);
-		EndpointDeliveryInfoDto infoForEmail = infos.getContent().stream().filter(i -> i.getEndpoint() instanceof EmailEndpoint).findFirst().get();
+		EndpointDeliveryInfoDto infoForEmail = infos.getContent().stream().filter(i -> i.getEndpoint() instanceof EmailEndpointDto).findFirst().get();
 
 		Instant now = Instant.now();
 
-		Assertions.assertThat(infoForEmail.getEndpoint().getId()).isEqualTo(emailEndPointId);
+		Assertions.assertThat(infoForEmail.getEndpoint().getId()).isEqualTo(emailEndPointId.toString());
 		Assertions.assertThat(infoForEmail.getStatusReachedAt()).isCloseTo(now, Assertions.within(1, ChronoUnit.MINUTES));
 		Assertions.assertThat(infoForEmail.getCurrentStatus()).isEqualTo(SENT);
 
-		EndpointDeliveryInfoDto infoForSms = infos.getContent().stream().filter(i -> i.getEndpoint() instanceof SmsEndpoint).findFirst().get();
+		EndpointDeliveryInfoDto infoForSms = infos.getContent().stream().filter(i -> i.getEndpoint() instanceof SmsEndpointDto).findFirst().get();
 
-		Assertions.assertThat(infoForSms.getEndpoint().getId()).isEqualTo(smsEndPointId);
+		Assertions.assertThat(infoForSms.getEndpoint().getId()).isEqualTo(smsEndPointId.toString());
 		Assertions.assertThat(infoForSms.getStatusReachedAt()).isCloseTo(now, Assertions.within(1, ChronoUnit.MINUTES));
 		Assertions.assertThat(infoForSms.getCurrentStatus()).isEqualTo(SENT);
 
@@ -209,8 +211,8 @@ class DeliveryInfoControllerTest extends BaseIntegrationTest {
 				.andExpect(jsonPath("$.content.[0].currentStatus").value(CoreMatchers.is("SENT")))
 				.andExpect(jsonPath("$.content.[0].statusReachedAt").value(DateFormatMatcher.matchesISO8601()))
 				.andExpect(jsonPath("$.content.[0].endpoint.email").value(CoreMatchers.is("jancuzy@gmail.com")))
-				.andExpect(jsonPath("$.content.[0].endpoint.endpointId").value(CoreMatchers.is("jancuzy@gmail.com")))
-				.andExpect(jsonPath("$.content.[0].endpoint.@type").value(CoreMatchers.is("EMAIL"))).andReturn();
+				.andExpect(jsonPath("$.content.[0].endpoint.value").value(CoreMatchers.is("jancuzy@gmail.com")))
+				.andExpect(jsonPath("$.content.[0].endpoint.type").value(CoreMatchers.is("EMAIL"))).andReturn();
 	}
 
 	@Test
@@ -238,11 +240,11 @@ class DeliveryInfoControllerTest extends BaseIntegrationTest {
 				.allMatch(endpointDeliveryInfoDto -> SENT.equals(endpointDeliveryInfoDto.getCurrentStatus()));
 
 		assertThat(deliveryInfosByMessageId)
-				.filteredOn(endpointDeliveryInfoDto -> "john.doe@gmail.com".equals(endpointDeliveryInfoDto.getEndpoint().getEndpointId()))
+				.filteredOn(endpointDeliveryInfoDto -> "john.doe@gmail.com".equals(endpointDeliveryInfoDto.getEndpoint().getValue()))
 				.isNotEmpty();
 
 		assertThat(deliveryInfosByMessageId)
-				.filteredOn(endpointDeliveryInfoDto -> "john.dudly@gmail.com".equals(endpointDeliveryInfoDto.getEndpoint().getEndpointId()))
+				.filteredOn(endpointDeliveryInfoDto -> "john.dudly@gmail.com".equals(endpointDeliveryInfoDto.getEndpoint().getValue()))
 				.isNotEmpty();
 	}
 
@@ -386,7 +388,7 @@ class DeliveryInfoControllerTest extends BaseIntegrationTest {
 				.andExpect(jsonPath("$.content", Matchers.hasSize(1)))
 				.andExpect(jsonPath("$.content.[0].endpoint.id", Matchers.is(email.getId().toString())))
 				.andExpect(jsonPath("$.content.[0].endpoint.email", Matchers.is(email.getEmail())))
-				.andExpect(jsonPath("$.content.[0].endpoint.endpointId", Matchers.is(email.getEndpointId())))
+				.andExpect(jsonPath("$.content.[0].endpoint.value", Matchers.is(email.getEndpointId())))
 				.andExpect(jsonPath("$.content.[0].currentStatus", Matchers.is(deliveryInfo.getStatus().name())));
 	}
 

--- a/src/test/java/com/obj/nc/controllers/EndpointsRestControllerTest.java
+++ b/src/test/java/com/obj/nc/controllers/EndpointsRestControllerTest.java
@@ -262,7 +262,7 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 	}
 
 	@Test
-	void testGetPage0Size20() throws Exception {
+	void testGetPage1Size20() throws Exception {
 		// GIVEN
 		persistNEmailEndpoints(19);
 
@@ -280,7 +280,7 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 	}
 
 	@Test
-	void testGetPage0Size10() throws Exception {
+	void testGetPage1Size10() throws Exception {
     	// GIVEN
 		persistNEmailEndpoints(19);
 
@@ -298,14 +298,14 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 	}
 
 	@Test
-	void testGetPage1Size10() throws Exception {
+	void testGetPage2Size10() throws Exception {
 		// GIVEN
 		persistNEmailEndpoints(19);
 
 		//WHEN
 		ResultActions resp = mockMvc
 				.perform(MockMvcRequestBuilders.get("/endpoints")
-						.param("page", "1")
+						.param("page", "2")
 						.param("size", "10")
 						.contentType(APPLICATION_JSON_UTF8)
 						.accept(APPLICATION_JSON_UTF8))

--- a/src/test/java/com/obj/nc/controllers/EventsRestControllerTest.java
+++ b/src/test/java/com/obj/nc/controllers/EventsRestControllerTest.java
@@ -472,7 +472,7 @@ class EventsRestControllerTest extends BaseIntegrationTest {
     }
 
     @Test
-    void testGetPage0Size20() throws Exception {
+    void testGetPage1Size20() throws Exception {
         // GIVEN
         persistNTestEvents(19);
 
@@ -490,7 +490,7 @@ class EventsRestControllerTest extends BaseIntegrationTest {
     }
 
     @Test
-    void testGetPage0Size10() throws Exception {
+    void testGetPage1Size10() throws Exception {
         // GIVEN
         persistNTestEvents(19);
 
@@ -508,14 +508,14 @@ class EventsRestControllerTest extends BaseIntegrationTest {
     }
 
     @Test
-    void testGetPage1Size10() throws Exception {
+    void testGetPage2Size10() throws Exception {
         // GIVEN
         persistNTestEvents(19);
 
         //WHEN
         ResultActions resp = mockMvc
                 .perform(MockMvcRequestBuilders.get("/events")
-                        .param("page", "1")
+                        .param("page", "2")
                         .param("size", "10")
                         .contentType(APPLICATION_JSON_UTF8)
                         .accept(APPLICATION_JSON_UTF8))

--- a/src/test/java/com/obj/nc/controllers/MessagesRestControllerTest.java
+++ b/src/test/java/com/obj/nc/controllers/MessagesRestControllerTest.java
@@ -238,7 +238,7 @@ class MessagesRestControllerTest extends BaseIntegrationTest {
         mockMvc
                 .perform(MockMvcRequestBuilders
                         .get("/messages")
-                        .param("page", "1")
+                        .param("page", "2")
                         .param("size", "10")
                         .accept(APPLICATION_JSON_UTF8))
                 .andExpect(status().is2xxSuccessful())


### PR DESCRIPTION
Here's how the response to a request with the query parameters 'page=2&size=20' looks like:

<img width="382" alt="image" src="https://user-images.githubusercontent.com/55783954/177234483-b8002dc9-4608-4197-a6ae-71c46d2ebabc.png">

Pagination is one-indexed, and is implemented using Spring's own resources (PageImpl, Page, Pageable). I extended PageImpl to minimize what Spring serializes as part of its Page object and to establish one-based indexing.

And here's how a serialized message looks  like:

<img width="1093" alt="image" src="https://user-images.githubusercontent.com/55783954/177234703-527f65fa-7b57-411f-bd97-15f30425121a.png">

It's the serialized form of a MessageContent object, from which various content types (EmailContent, SmsContent, etc) inherit. So if the message is an email, we'll see an email-specific content structure.

I tried to keep my changes as minimal and less intrusive as possible to not cause extensive breaks in tests and elsewhere. Tests required slight modifications to get them back to normal.