### PR TITLE
Refactor delivery info fetching

### DIFF
--- a/src/main/java/com/obj/nc/domain/pagination/ResultPage.java
+++ b/src/main/java/com/obj/nc/domain/pagination/ResultPage.java
@@ -51,6 +51,11 @@ public class ResultPage<T> extends PageImpl<T> {
     }
 
     @JsonProperty
+    public int getNumberOfElements() {
+        return super.getNumberOfElements();
+    }
+
+    @JsonProperty
     public long getTotalElements() {
         return super.getTotalElements();
     }

--- a/src/main/java/com/obj/nc/flows/testmode/TestModeProperties.java
+++ b/src/main/java/com/obj/nc/flows/testmode/TestModeProperties.java
@@ -20,9 +20,11 @@
 package com.obj.nc.flows.testmode;
 
 import lombok.Data;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @Data
@@ -34,6 +36,8 @@ public class TestModeProperties {
     private List<String> recipients;
 
     private int pollMockSourcesPeriodInSeconds=5;
+
+    private int maxMessagesPerPoll = 50;
     
     private boolean enabled = false;
 

--- a/src/main/java/com/obj/nc/flows/testmode/sms/config/TestModeSmsFlowConfig.java
+++ b/src/main/java/com/obj/nc/flows/testmode/sms/config/TestModeSmsFlowConfig.java
@@ -49,9 +49,9 @@ public class TestModeSmsFlowConfig {
     @DependsOn(TestModeFlowConfig.TEST_MODE_AGGREGATE_AND_SEND_FLOW_NAME)
     public IntegrationFlow testModeProcessReceivedSmsMessage() {
         return IntegrationFlows
-        		.fromSupplier(inMemorySmsSource,
-                      config -> config.poller(Pollers.trigger(testModeSourceTrigger()))
-                      .id(TEST_MODE_SMS_SOURCE_BEAN_NAME))
+        		.fromSupplier(inMemorySmsSource, config -> config
+                        .poller(Pollers.trigger(testModeSourceTrigger()).maxMessagesPerPoll(testModeProps.getMaxMessagesPerPoll()))
+                        .id(TEST_MODE_SMS_SOURCE_BEAN_NAME))
         		.split()
         		.channel(TestModeFlowConfig.TEST_MODE_THREAD_EXECUTOR_CHANNEL_NAME)
         		.get();

--- a/src/test/java/com/obj/nc/controllers/DeliveryInfoControllerTest.java
+++ b/src/test/java/com/obj/nc/controllers/DeliveryInfoControllerTest.java
@@ -375,11 +375,15 @@ class DeliveryInfoControllerTest extends BaseIntegrationTest {
 		message.setPreviousEventIds(Collections.singletonList(event.getEventId()));
 		message = messageRepo.save(message.toPersistentState()).toMessage();
 
-		DeliveryInfo deliveryInfo = DeliveryInfo.builder()
+		DeliveryInfo d1 = DeliveryInfo.builder()
 				.endpointId(email.getId()).messageId(message.getId()).status(DELIVERY_STATUS.PROCESSING)
 				.id(UUID.randomUUID()).build();
+		DeliveryInfo d2 = DeliveryInfo.builder()
+				.endpointId(email.getId()).messageId(message.getId()).status(DELIVERY_STATUS.SENT)
+				.id(UUID.randomUUID()).build();
 
-		deliveryRepo.save(deliveryInfo);
+		deliveryRepo.save(d1);
+		deliveryRepo.save(d2);
 
 		// WHEN
 		mockMvc.perform(MockMvcRequestBuilders.get("/delivery-info/events/ext/{extId}", event.getExternalId())
@@ -389,7 +393,7 @@ class DeliveryInfoControllerTest extends BaseIntegrationTest {
 				.andExpect(jsonPath("$.content.[0].endpoint.id", Matchers.is(email.getId().toString())))
 				.andExpect(jsonPath("$.content.[0].endpoint.email", Matchers.is(email.getEmail())))
 				.andExpect(jsonPath("$.content.[0].endpoint.value", Matchers.is(email.getEndpointId())))
-				.andExpect(jsonPath("$.content.[0].currentStatus", Matchers.is(deliveryInfo.getStatus().name())));
+				.andExpect(jsonPath("$.content.[0].currentStatus", Matchers.is(d2.getStatus().name())));
 	}
 
 	@Test


### PR DESCRIPTION
Since we've parallelized message processing (and sending), the old way of fetching delivery infos by order of processing makes tests fail by causing subtle bugs.