### PR TITLE
fix paging

### DIFF
--- a/src/main/java/com/obj/nc/config/NcAppConfigProperties.java
+++ b/src/main/java/com/obj/nc/config/NcAppConfigProperties.java
@@ -47,4 +47,16 @@ public class NcAppConfigProperties {
     @Value("${nc.app.url.context-path:/notiflow}")
     private String contextPath;
 
+    private Web web = new Web();
+
+    @Data
+    public static class Web {
+        private Paging paging = new Paging();
+
+        @Data
+        public static class Paging {
+            private int maxPageSize = 2000;
+            private boolean oneIndexedParameters = true;
+        }
+    }
 }

--- a/src/main/java/com/obj/nc/config/PagingConfigProperties.java
+++ b/src/main/java/com/obj/nc/config/PagingConfigProperties.java
@@ -20,31 +20,13 @@
 package com.obj.nc.config;
 
 import lombok.Data;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Data
 @Configuration
-@ConfigurationProperties("nc.app")
-public class NcAppConfigProperties {
-    
-    private String url;
-    private boolean checkReferenceIntegrity = false;
-
-    @Value("${nc.app.executor.core-pool-size:10}")
-    private int corePoolSize;
-
-    @Value("${nc.app.executor.max-pool-size:20}")
-    private int maxPoolSize;
-
-    @Value("${nc.app.executor.queue-capacity:1000}")
-    private int queueCapacity;
-
-    @Value("${nc.app.executor.block-policy-wait-time:5}")
-    private int blockPolicyWaitTimeInSec;
-
-    @Value("${nc.app.url.context-path:/notiflow}")
-    private String contextPath;
-
+@ConfigurationProperties("nc.app.paging")
+public class PagingConfigProperties {
+    private int maxPageSize = 2000;
+    private boolean oneIndexedParameters = true;
 }

--- a/src/main/java/com/obj/nc/controllers/DeliveryInfoRestController.java
+++ b/src/main/java/com/obj/nc/controllers/DeliveryInfoRestController.java
@@ -42,7 +42,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -52,6 +51,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static com.obj.nc.utils.PagingUtils.createPageRequest;
 
 @Slf4j
 @Validated
@@ -70,8 +71,11 @@ public class DeliveryInfoRestController {
 	public ResultPage<EndpointDeliveryInfoDto> findDeliveryInfosByEventId(
 			@PathVariable (value = "eventId", required = true) String eventId,
 			@RequestParam(value = "endpointId", required = false) String endpointId,
-			@PageableDefault(size = 20) Pageable pageable
+			@RequestParam("page") int page,
+			@RequestParam("size") int size
 	) {
+		Pageable pageable = createPageRequest(page, size, ncAppConfigProperties.getWeb().getPaging());
+
 		UUID endpointUUID = endpointId == null ? null : UUID.fromString(endpointId);
 
 		long total = deliveryRepo.countByEventIdAndEndpointId(UUID.fromString(eventId), endpointUUID);
@@ -114,7 +118,8 @@ public class DeliveryInfoRestController {
 	public ResultPage<EndpointDeliveryInfoDto> findDeliveryInfosByExtId(
 			@PathVariable (value = "extEventId", required = true) String extEventId,
 			@RequestParam(value = "endpointId", required = false) String endpointId,
-			@PageableDefault(size = 20) Pageable pageable
+			@RequestParam("page") int page,
+			@RequestParam("size") int size
 	) {
 
 		GenericEvent event = eventRepo.findByExternalId(extEventId);
@@ -122,7 +127,7 @@ public class DeliveryInfoRestController {
 			throw new IllegalArgumentException("Event with " +  extEventId +" external ID not found");
 		}
 
-		return findDeliveryInfosByEventId(event.getId().toString(), endpointId, pageable);
+		return findDeliveryInfosByEventId(event.getId().toString(), endpointId, page, size);
 	}
 
 	@GetMapping(value = "/messages/{messageId}/mark-as-read")

--- a/src/main/java/com/obj/nc/controllers/DeliveryInfoRestController.java
+++ b/src/main/java/com/obj/nc/controllers/DeliveryInfoRestController.java
@@ -21,6 +21,7 @@ package com.obj.nc.controllers;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.obj.nc.config.NcAppConfigProperties;
+import com.obj.nc.config.PagingConfigProperties;
 import com.obj.nc.domain.content.MessageContent;
 import com.obj.nc.domain.dto.content.MessageContentDto;
 import com.obj.nc.domain.dto.endpoint.ReceivingEndpointDto;
@@ -66,6 +67,7 @@ public class DeliveryInfoRestController {
     @Autowired private MessageRepository messageRepo;
 	@Autowired private DeliveryInfoFlow deliveryInfoFlow;
 	@Autowired private NcAppConfigProperties ncAppConfigProperties;
+	@Autowired private PagingConfigProperties pagingConfigProperties;
 
 	@GetMapping(value = "/events/{eventId}", produces="application/json")
 	public ResultPage<EndpointDeliveryInfoDto> findDeliveryInfosByEventId(
@@ -74,7 +76,7 @@ public class DeliveryInfoRestController {
 			@RequestParam("page") int page,
 			@RequestParam("size") int size
 	) {
-		Pageable pageable = createPageRequest(page, size, ncAppConfigProperties.getWeb().getPaging());
+		Pageable pageable = createPageRequest(page, size, pagingConfigProperties);
 
 		UUID endpointUUID = endpointId == null ? null : UUID.fromString(endpointId);
 

--- a/src/main/java/com/obj/nc/controllers/EndpointsRestController.java
+++ b/src/main/java/com/obj/nc/controllers/EndpointsRestController.java
@@ -19,7 +19,7 @@
 
 package com.obj.nc.controllers;
 
-import com.obj.nc.config.NcAppConfigProperties;
+import com.obj.nc.config.PagingConfigProperties;
 import com.obj.nc.domain.dto.EndpointTableViewDto;
 import com.obj.nc.domain.dto.EndpointTableViewDto.EndpointType;
 import com.obj.nc.domain.endpoints.ReceivingEndpoint;
@@ -49,7 +49,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 public class EndpointsRestController {
     
     private final EndpointsRepository endpointsRepository;
-    private final NcAppConfigProperties ncAppConfigProperties;
+    private final PagingConfigProperties pagingConfigProperties;
     
     @GetMapping(produces = APPLICATION_JSON_VALUE)
     public Page<EndpointTableViewDto> findAllEndpoints(@RequestParam(value = "processedFrom", required = false, defaultValue = "2000-01-01T12:00:00Z")
@@ -61,7 +61,7 @@ public class EndpointsRestController {
                                                        @RequestParam(value = "endpointId", required = false) UUID endpointId,
                                                        @RequestParam("page") int page,
                                                        @RequestParam("size") int size) {
-        Pageable pageable = createPageRequest(page, size, ncAppConfigProperties.getWeb().getPaging());
+        Pageable pageable = createPageRequest(page, size, pagingConfigProperties);
         List<EndpointTableViewDto> endpoints = endpointsRepository
                 .findAllEndpointsWithStats(processedFrom, processedTo, endpointType, eventId, endpointId, pageable.getOffset(), pageable.getPageSize())
                 .stream()

--- a/src/main/java/com/obj/nc/controllers/EndpointsRestController.java
+++ b/src/main/java/com/obj/nc/controllers/EndpointsRestController.java
@@ -19,6 +19,7 @@
 
 package com.obj.nc.controllers;
 
+import com.obj.nc.config.NcAppConfigProperties;
 import com.obj.nc.domain.dto.EndpointTableViewDto;
 import com.obj.nc.domain.dto.EndpointTableViewDto.EndpointType;
 import com.obj.nc.domain.endpoints.ReceivingEndpoint;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.obj.nc.utils.PagingUtils.createPageRequest;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Validated
@@ -47,6 +49,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 public class EndpointsRestController {
     
     private final EndpointsRepository endpointsRepository;
+    private final NcAppConfigProperties ncAppConfigProperties;
     
     @GetMapping(produces = APPLICATION_JSON_VALUE)
     public Page<EndpointTableViewDto> findAllEndpoints(@RequestParam(value = "processedFrom", required = false, defaultValue = "2000-01-01T12:00:00Z")
@@ -56,7 +59,9 @@ public class EndpointsRestController {
                                                        @RequestParam(value = "endpointType", required = false) EndpointType endpointType,
                                                        @RequestParam(value = "eventId", required = false) UUID eventId,
                                                        @RequestParam(value = "endpointId", required = false) UUID endpointId,
-                                                       Pageable pageable) {
+                                                       @RequestParam("page") int page,
+                                                       @RequestParam("size") int size) {
+        Pageable pageable = createPageRequest(page, size, ncAppConfigProperties.getWeb().getPaging());
         List<EndpointTableViewDto> endpoints = endpointsRepository
                 .findAllEndpointsWithStats(processedFrom, processedTo, endpointType, eventId, endpointId, pageable.getOffset(), pageable.getPageSize())
                 .stream()

--- a/src/main/java/com/obj/nc/controllers/EventsRestController.java
+++ b/src/main/java/com/obj/nc/controllers/EventsRestController.java
@@ -20,6 +20,7 @@
 package com.obj.nc.controllers;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.obj.nc.config.NcAppConfigProperties;
 import com.obj.nc.domain.dto.DeliveryStatsByEndpointType;
 import com.obj.nc.domain.dto.GenericEventTableViewDto;
 import com.obj.nc.domain.event.EventReceiverResponse;
@@ -54,6 +55,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static com.obj.nc.utils.PagingUtils.createPageRequest;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Validated
@@ -66,7 +68,8 @@ public class EventsRestController {
 	private final SimpleJsonValidator simpleJsonValidator;
 	private final GenericEventJsonSchemaValidator jsonSchemaValidator;
 	private final GenericEventRepository eventsRepository;
-	private final EventSummaryNotificationProperties summaryNotifProps; 
+	private final EventSummaryNotificationProperties summaryNotifProps;
+	private final NcAppConfigProperties ncAppConfigProperties;
 	
 	@PostMapping( consumes="application/json", produces="application/json")
     public EventReceiverResponse persistGenericEvent(
@@ -112,7 +115,9 @@ public class EventsRestController {
 														@RequestParam(value = "consumedTo", required = false, defaultValue = "9999-01-01T12:00:00Z") 
 															@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant consumedTo,
 														@RequestParam(value = "eventId", required = false) String eventId,
-														Pageable pageable) {
+														@RequestParam("page") int page,
+														@RequestParam("size") int size) {
+		Pageable pageable = createPageRequest(page, size, ncAppConfigProperties.getWeb().getPaging());
 		UUID eventUUID = eventId == null ? null : UUID.fromString(eventId);
 		
 		List<GenericEventTableViewDto> events = eventsRepository

--- a/src/main/java/com/obj/nc/controllers/EventsRestController.java
+++ b/src/main/java/com/obj/nc/controllers/EventsRestController.java
@@ -20,7 +20,7 @@
 package com.obj.nc.controllers;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.obj.nc.config.NcAppConfigProperties;
+import com.obj.nc.config.PagingConfigProperties;
 import com.obj.nc.domain.dto.DeliveryStatsByEndpointType;
 import com.obj.nc.domain.dto.GenericEventTableViewDto;
 import com.obj.nc.domain.event.EventReceiverResponse;
@@ -41,13 +41,7 @@ import org.springframework.data.relational.core.conversion.DbActionExecutionExce
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
@@ -69,7 +63,7 @@ public class EventsRestController {
 	private final GenericEventJsonSchemaValidator jsonSchemaValidator;
 	private final GenericEventRepository eventsRepository;
 	private final EventSummaryNotificationProperties summaryNotifProps;
-	private final NcAppConfigProperties ncAppConfigProperties;
+	private final PagingConfigProperties pagingConfigProperties;
 	
 	@PostMapping( consumes="application/json", produces="application/json")
     public EventReceiverResponse persistGenericEvent(
@@ -117,7 +111,7 @@ public class EventsRestController {
 														@RequestParam(value = "eventId", required = false) String eventId,
 														@RequestParam("page") int page,
 														@RequestParam("size") int size) {
-		Pageable pageable = createPageRequest(page, size, ncAppConfigProperties.getWeb().getPaging());
+		Pageable pageable = createPageRequest(page, size, pagingConfigProperties);
 		UUID eventUUID = eventId == null ? null : UUID.fromString(eventId);
 		
 		List<GenericEventTableViewDto> events = eventsRepository

--- a/src/main/java/com/obj/nc/controllers/MessagesRestController.java
+++ b/src/main/java/com/obj/nc/controllers/MessagesRestController.java
@@ -19,6 +19,7 @@
 
 package com.obj.nc.controllers;
 
+import com.obj.nc.config.NcAppConfigProperties;
 import com.obj.nc.domain.dto.MessageTableViewDto;
 import com.obj.nc.domain.dto.SendEmailMessageRequest;
 import com.obj.nc.domain.message.EmailMessage;
@@ -29,7 +30,6 @@ import com.obj.nc.flows.messageProcessing.MessageProcessingFlow;
 import com.obj.nc.repositories.MessageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -47,6 +47,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
+import static com.obj.nc.utils.PagingUtils.createPageRequest;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @Validated
@@ -57,6 +58,7 @@ public class MessagesRestController {
     
     private final MessageProcessingFlow messageProcessingFlow;
     private final MessageRepository messageRepository;
+    private final NcAppConfigProperties ncAppConfigProperties;
 	
 	@PostMapping(path = "/send-email", consumes="application/json", produces="application/json")
     public SendMessageResponse receiveEmailMessage(@RequestBody(required = true) SendEmailMessageRequest emailMessageRequest) {
@@ -71,7 +73,9 @@ public class MessagesRestController {
                                                      @RequestParam(value = "createdTo", required = false, defaultValue = "9999-01-01T12:00:00Z") 
                                                         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant createdTo,
                                                      @RequestParam(value = "eventId", required = false) String eventId,
-                                                     Pageable pageable) {
+                                                     @RequestParam("page") int page,
+                                                     @RequestParam("size") int size) {
+        Pageable pageable = createPageRequest(page, size, ncAppConfigProperties.getWeb().getPaging());
         UUID eventUUID = eventId == null ? null : UUID.fromString(eventId);
         
         List<MessageTableViewDto> messages = messageRepository

--- a/src/main/java/com/obj/nc/controllers/MessagesRestController.java
+++ b/src/main/java/com/obj/nc/controllers/MessagesRestController.java
@@ -19,7 +19,7 @@
 
 package com.obj.nc.controllers;
 
-import com.obj.nc.config.NcAppConfigProperties;
+import com.obj.nc.config.PagingConfigProperties;
 import com.obj.nc.domain.dto.MessageTableViewDto;
 import com.obj.nc.domain.dto.SendEmailMessageRequest;
 import com.obj.nc.domain.message.EmailMessage;
@@ -34,13 +34,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Instant;
@@ -58,8 +52,8 @@ public class MessagesRestController {
     
     private final MessageProcessingFlow messageProcessingFlow;
     private final MessageRepository messageRepository;
-    private final NcAppConfigProperties ncAppConfigProperties;
-	
+    private final PagingConfigProperties pagingConfigProperties;
+
 	@PostMapping(path = "/send-email", consumes="application/json", produces="application/json")
     public SendMessageResponse receiveEmailMessage(@RequestBody(required = true) SendEmailMessageRequest emailMessageRequest) {
         EmailMessage message = emailMessageRequest.toEmailMessage();
@@ -75,7 +69,7 @@ public class MessagesRestController {
                                                      @RequestParam(value = "eventId", required = false) String eventId,
                                                      @RequestParam("page") int page,
                                                      @RequestParam("size") int size) {
-        Pageable pageable = createPageRequest(page, size, ncAppConfigProperties.getWeb().getPaging());
+        Pageable pageable = createPageRequest(page, size, pagingConfigProperties);
         UUID eventUUID = eventId == null ? null : UUID.fromString(eventId);
         
         List<MessageTableViewDto> messages = messageRepository

--- a/src/main/java/com/obj/nc/testUtils/BaseIntegrationTest.java
+++ b/src/main/java/com/obj/nc/testUtils/BaseIntegrationTest.java
@@ -44,9 +44,12 @@ import org.springframework.integration.endpoint.PollingConsumer;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import static com.obj.nc.flows.emailFormattingAndSending.EmailProcessingFlowConfig.EMAIL_SENDER_MESSAGE_HANDLER;
 import static com.obj.nc.flows.inputEventRouting.config.InputEventRoutingFlowConfig.GENERIC_EVENT_CHANNEL_ADAPTER_BEAN_NAME;
+import static java.util.Collections.singletonList;
 
 
 import javax.mail.MessagingException;
@@ -234,4 +237,10 @@ public abstract class BaseIntegrationTest implements ApplicationContextAware {
 		Awaitility.await().atMost(Duration.ofSeconds(numberOfSeconds)).until(() -> taskScheduler.getActiveCount()==0);
 	}
 
+	public MultiValueMap<String, String> getDefaultPagingParams() {
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.put("page", singletonList("1"));
+		params.put("size", singletonList("20"));
+		return params;
+	}
 }

--- a/src/main/java/com/obj/nc/utils/PagingUtils.java
+++ b/src/main/java/com/obj/nc/utils/PagingUtils.java
@@ -1,6 +1,6 @@
 package com.obj.nc.utils;
 
-import com.obj.nc.config.NcAppConfigProperties.Web.Paging;
+import com.obj.nc.config.PagingConfigProperties;
 import com.obj.nc.exceptions.PayloadValidationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -10,7 +10,7 @@ import java.util.function.Predicate;
 import static java.lang.String.format;
 
 public class PagingUtils {
-    public static Pageable createPageRequest(int pageNumber, int pageSize, Paging pagingProps) {
+    public static Pageable createPageRequest(int pageNumber, int pageSize, PagingConfigProperties pagingProps) {
         int maxPageSize = pagingProps.getMaxPageSize();
         boolean oneIndexedParameters = pagingProps.isOneIndexedParameters();
         int lowerBound = oneIndexedParameters ? 1 : 0;

--- a/src/main/java/com/obj/nc/utils/PagingUtils.java
+++ b/src/main/java/com/obj/nc/utils/PagingUtils.java
@@ -1,0 +1,31 @@
+package com.obj.nc.utils;
+
+import com.obj.nc.config.NcAppConfigProperties.Web.Paging;
+import com.obj.nc.exceptions.PayloadValidationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.function.Predicate;
+
+import static java.lang.String.format;
+
+public class PagingUtils {
+    public static Pageable createPageRequest(int pageNumber, int pageSize, Paging pagingProps) {
+        int maxPageSize = pagingProps.getMaxPageSize();
+        boolean oneIndexedParameters = pagingProps.isOneIndexedParameters();
+        int lowerBound = oneIndexedParameters ? 1 : 0;
+
+        assertCondition(pageNumber, n -> n >= lowerBound,
+                format("Page number is out of bounds: %d, indexed from one: %b", pageNumber, oneIndexedParameters));
+        assertCondition(pageSize, s -> s <= maxPageSize,
+                format("Page size is out of bounds: %d, max page size: %d", pageSize, maxPageSize));
+
+        return PageRequest.of(pageNumber - lowerBound, pageSize);
+    }
+
+    private static <T> void assertCondition(T obj, Predicate<T> condition, String errorMessage) {
+        if (!condition.test(obj)) {
+            throw new PayloadValidationException(errorMessage);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,5 +40,5 @@ nc.flows.event-summary-notif.default-summary-email-creation=true
 server.port=${nc.app.url.port}
 server.servlet.context-path=${nc.app.url.context-path}
 
-nc.app.web.paging.maxPageSize=2000
-nc.app.web.paging.oneIndexedParameters=true
+nc.app.paging.maxPageSize=2000
+nc.app.paging.oneIndexedParameters=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,4 +40,5 @@ nc.flows.event-summary-notif.default-summary-email-creation=true
 server.port=${nc.app.url.port}
 server.servlet.context-path=${nc.app.url.context-path}
 
-spring.data.web.pageable.one-indexed-parameters=true
+nc.app.web.paging.maxPageSize=2000
+nc.app.web.paging.oneIndexedParameters=true

--- a/src/test/java/com/obj/nc/controllers/EndpointsRestControllerTest.java
+++ b/src/test/java/com/obj/nc/controllers/EndpointsRestControllerTest.java
@@ -108,6 +108,7 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 		//WHEN TEST REST
         ResultActions resp = mockMvc
         		.perform(MockMvcRequestBuilders.get("/endpoints")
+				.params(getDefaultPagingParams())
                 .contentType(APPLICATION_JSON_UTF8)
         		.accept(APPLICATION_JSON_UTF8))
         		.andDo(MockMvcResultHandlers.print());
@@ -130,6 +131,7 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 		//WHEN
 		ResultActions resp = mockMvc
 				.perform(MockMvcRequestBuilders.get("/endpoints")
+						.params(getDefaultPagingParams())
 						.contentType(APPLICATION_JSON_UTF8)
 						.accept(APPLICATION_JSON_UTF8))
 				.andDo(MockMvcResultHandlers.print());
@@ -153,6 +155,7 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 		//WHEN
 		ResultActions resp = mockMvc
 				.perform(MockMvcRequestBuilders.get("/endpoints")
+						.params(getDefaultPagingParams())
 						.param("processedFrom", Instant.now().minusSeconds(60).toString())
 						.param("processedTo", Instant.now().plusSeconds(60).toString())
 						.contentType(APPLICATION_JSON_UTF8)
@@ -178,6 +181,7 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 		//WHEN
 		ResultActions resp = mockMvc
 				.perform(MockMvcRequestBuilders.get("/endpoints")
+						.params(getDefaultPagingParams())
 						.param("processedFrom", Instant.now().minusSeconds(60).toString())
 						.contentType(APPLICATION_JSON_UTF8)
 						.accept(APPLICATION_JSON_UTF8))
@@ -202,6 +206,7 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 		//WHEN
 		ResultActions resp = mockMvc
 				.perform(MockMvcRequestBuilders.get("/endpoints")
+						.params(getDefaultPagingParams())
 						.param("processedTo", Instant.now().plusSeconds(60).toString())
 						.contentType(APPLICATION_JSON_UTF8)
 						.accept(APPLICATION_JSON_UTF8))
@@ -226,6 +231,7 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 		//WHEN
 		ResultActions resp = mockMvc
 				.perform(MockMvcRequestBuilders.get("/endpoints")
+						.params(getDefaultPagingParams())
 						.param("endpointType", "SMS")
 						.accept(APPLICATION_JSON_UTF8))
 				.andDo(MockMvcResultHandlers.print());
@@ -247,6 +253,7 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 		//WHEN
 		ResultActions resp = mockMvc
 				.perform(MockMvcRequestBuilders.get("/endpoints")
+						.params(getDefaultPagingParams())
 						.param("eventId", eventId.toString())
 						.accept(APPLICATION_JSON_UTF8))
 				.andDo(MockMvcResultHandlers.print());
@@ -269,7 +276,7 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 		//WHEN
 		ResultActions resp = mockMvc
 				.perform(MockMvcRequestBuilders.get("/endpoints")
-						.param("page", "0")
+						.param("page", "1")
 						.param("size", "20")
 						.contentType(APPLICATION_JSON_UTF8)
 						.accept(APPLICATION_JSON_UTF8))
@@ -287,7 +294,7 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 		//WHEN
 		ResultActions resp = mockMvc
 				.perform(MockMvcRequestBuilders.get("/endpoints")
-						.param("page", "0")
+						.param("page", "1")
 						.param("size", "10")
 						.contentType(APPLICATION_JSON_UTF8)
 						.accept(APPLICATION_JSON_UTF8))
@@ -323,6 +330,7 @@ class EndpointsRestControllerTest extends BaseIntegrationTest {
 		//WHEN
 		ResultActions resp = mockMvc
 				.perform(MockMvcRequestBuilders.get("/endpoints")
+						.params(getDefaultPagingParams())
 						.param("endpointId", endpointId.toString())
 						.accept(APPLICATION_JSON_UTF8))
 				.andDo(MockMvcResultHandlers.print());

--- a/src/test/java/com/obj/nc/controllers/EventsRestControllerTest.java
+++ b/src/test/java/com/obj/nc/controllers/EventsRestControllerTest.java
@@ -379,6 +379,7 @@ class EventsRestControllerTest extends BaseIntegrationTest {
         //WHEN TEST REST
         ResultActions resp = mockMvc
                 .perform(MockMvcRequestBuilders.get("/events")
+                        .params(getDefaultPagingParams())
                         .contentType(APPLICATION_JSON_UTF8)
                         .accept(APPLICATION_JSON_UTF8))
                 .andDo(MockMvcResultHandlers.print());
@@ -399,6 +400,7 @@ class EventsRestControllerTest extends BaseIntegrationTest {
         //WHEN
         ResultActions resp = mockMvc
                 .perform(MockMvcRequestBuilders.get("/events")
+                        .params(getDefaultPagingParams())
                         .param("consumedFrom", Instant.now().minus(20, ChronoUnit.MINUTES).toString())
                         .param("consumedTo", Instant.now().plus(150, ChronoUnit.MINUTES).toString())
                         .contentType(APPLICATION_JSON_UTF8)
@@ -421,6 +423,7 @@ class EventsRestControllerTest extends BaseIntegrationTest {
         //WHEN
         ResultActions resp = mockMvc
                 .perform(MockMvcRequestBuilders.get("/events")
+                        .params(getDefaultPagingParams())
                         .param("consumedFrom", Instant.now().plus(150, ChronoUnit.MINUTES).toString())
                         .contentType(APPLICATION_JSON_UTF8)
                         .accept(APPLICATION_JSON_UTF8))
@@ -442,6 +445,7 @@ class EventsRestControllerTest extends BaseIntegrationTest {
         //WHEN
         ResultActions resp = mockMvc
                 .perform(MockMvcRequestBuilders.get("/events")
+                        .params(getDefaultPagingParams())
                         .param("consumedTo", Instant.now().plus(150, ChronoUnit.MINUTES).toString())
                         .contentType(APPLICATION_JSON_UTF8)
                         .accept(APPLICATION_JSON_UTF8))
@@ -463,6 +467,7 @@ class EventsRestControllerTest extends BaseIntegrationTest {
         //WHEN
         ResultActions resp = mockMvc
                 .perform(MockMvcRequestBuilders.get("/events")
+                        .params(getDefaultPagingParams())
                         .param("eventId", eventIds.get(0).toString())
                         .accept(APPLICATION_JSON_UTF8))
                 .andDo(MockMvcResultHandlers.print());
@@ -483,7 +488,7 @@ class EventsRestControllerTest extends BaseIntegrationTest {
         //WHEN
         ResultActions resp = mockMvc
                 .perform(MockMvcRequestBuilders.get("/events")
-                        .param("page", "0")
+                        .param("page", "1")
                         .param("size", "20")
                         .contentType(APPLICATION_JSON_UTF8)
                         .accept(APPLICATION_JSON_UTF8))
@@ -501,7 +506,7 @@ class EventsRestControllerTest extends BaseIntegrationTest {
         //WHEN
         ResultActions resp = mockMvc
                 .perform(MockMvcRequestBuilders.get("/events")
-                        .param("page", "0")
+                        .param("page", "1")
                         .param("size", "10")
                         .contentType(APPLICATION_JSON_UTF8)
                         .accept(APPLICATION_JSON_UTF8))

--- a/src/test/java/com/obj/nc/controllers/MessagesRestControllerTest.java
+++ b/src/test/java/com/obj/nc/controllers/MessagesRestControllerTest.java
@@ -144,6 +144,7 @@ class MessagesRestControllerTest extends BaseIntegrationTest {
         mockMvc
                 .perform(MockMvcRequestBuilders
                         .get("/messages")
+                        .params(getDefaultPagingParams())
                         .accept(APPLICATION_JSON_UTF8))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(jsonPath("$.content.size()", Matchers.is(19)))
@@ -161,6 +162,7 @@ class MessagesRestControllerTest extends BaseIntegrationTest {
         mockMvc
                 .perform(MockMvcRequestBuilders
                         .get("/messages")
+                        .params(getDefaultPagingParams())
                         .param("createdFrom", Instant.now().minus(10, ChronoUnit.DAYS).toString())
                         .accept(APPLICATION_JSON_UTF8))
                 .andExpect(status().is2xxSuccessful())
@@ -176,6 +178,7 @@ class MessagesRestControllerTest extends BaseIntegrationTest {
         mockMvc
                 .perform(MockMvcRequestBuilders
                         .get("/messages")
+                        .params(getDefaultPagingParams())
                         .param("createdTo", Instant.now().minus(10, ChronoUnit.DAYS).toString())
                         .accept(APPLICATION_JSON_UTF8))
                 .andExpect(status().is2xxSuccessful())
@@ -191,6 +194,7 @@ class MessagesRestControllerTest extends BaseIntegrationTest {
         mockMvc
                 .perform(MockMvcRequestBuilders
                         .get("/messages")
+                        .params(getDefaultPagingParams())
                         .param("createdFrom", Instant.now().minus(15, ChronoUnit.DAYS).toString())
                         .param("createdTo", Instant.now().minus(10, ChronoUnit.DAYS).toString())
                         .accept(APPLICATION_JSON_UTF8))
@@ -207,6 +211,7 @@ class MessagesRestControllerTest extends BaseIntegrationTest {
         mockMvc
                 .perform(MockMvcRequestBuilders
                         .get("/messages")
+                        .params(getDefaultPagingParams())
                         .param("eventId", eventId.toString())
                         .accept(APPLICATION_JSON_UTF8))
                 .andExpect(status().is2xxSuccessful())
@@ -222,7 +227,7 @@ class MessagesRestControllerTest extends BaseIntegrationTest {
         mockMvc
                 .perform(MockMvcRequestBuilders
                         .get("/messages")
-                        .param("page", "0")
+                        .param("page", "1")
                         .param("size", "10")
                         .accept(APPLICATION_JSON_UTF8))
                 .andExpect(status().is2xxSuccessful())


### PR DESCRIPTION
Chyba strankovania

**Zadanie od Martina:**

Podozrive bolo strankovanie - 1. strana, znova 1. strana, 2. strana, 3. strana, ... Takze to bola chyba komunikacie medzi SIA a NC. SIA ocakavala strankovanie od 0 a NC ocakavalo strankovanie od 1.
Takze momentalne to uz funguje.

Aj tak ale poprosim upravit notifikacne centrum, aby hadzalo chyby a neupravovalo nasilu chybove stavy na nejake fejkovane vysledky. Mame teda uz 2 problemy:
http://localhost:8088/delivery-info/events/ext/108713-start?page=0&size=3 - malo by vyhlasit chybu, ze strana 0 je mimo ocakavaneho rozsahu, namiesto toho NC bez slova vrati stranu 1
http://localhost:8088/delivery-info/events/ext/108713-start?page=1&size=3 - OK, vrati stranu 1
[http://localhost:8088/delivery-info/events/ext/108713-start?page=3&size=3000](http://localhost:8088/delivery-info/events/ext/108713-start?page=3&size=3000=) - malo by vyhlasit chybu, ze 3000 je mimo ocakavaneho rozsahu, namiesto toho bez slova osekne vysledky na 2000 zaznamov.