### PR TITLE
publish only on tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,6 @@ name: Publish
 
 on:
   push:
-    branches:
-      - master
-      - 'release/*'
-      - 'hotfix/*'
     tags:
       - 'v*'
 


### PR DESCRIPTION
nebolo kompatibilne s git flow release, snazilo sa publishnut naraz z mastra aj z tagu a vysledkom bolo zlyhanie, myslim, ze nam staci releasovat tagy
