### PR TITLE
Feature/new and changed pull data hash attributes

### DIFF
--- a/src/main/java/com/obj/nc/flows/dataSources/JobConfig.java
+++ b/src/main/java/com/obj/nc/flows/dataSources/JobConfig.java
@@ -19,10 +19,16 @@ package com.obj.nc.flows.dataSources;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Setter
 @Getter
 public class JobConfig {
     private String externalIdAttrName;
     private String pojoFCCN;
     private String spelFilterExpression;
+
+    // empty == all
+    private List<String> hashAttributes = new ArrayList<>();
 }

--- a/src/main/java/com/obj/nc/flows/dataSources/firestore/FirestoreDataSourceFlowsConfiguration.java
+++ b/src/main/java/com/obj/nc/flows/dataSources/firestore/FirestoreDataSourceFlowsConfiguration.java
@@ -63,6 +63,7 @@ public class FirestoreDataSourceFlowsConfiguration {
         jobConfig.setExternalIdAttrName(jobProperties.getExternalIdAttrName());
         jobConfig.setPojoFCCN(jobProperties.getPojoFCCN());
         jobConfig.setSpelFilterExpression(jobProperties.getSpelFilterExpression());
+        jobConfig.setHashAttributes(jobProperties.getHashAttributes());
 
         return nextFlow.continueFlow(IntegrationFlows.from(
                 firestoreChannelAdapter,

--- a/src/main/java/com/obj/nc/flows/dataSources/firestore/properties/FirestoreJobProperties.java
+++ b/src/main/java/com/obj/nc/flows/dataSources/firestore/properties/FirestoreJobProperties.java
@@ -29,4 +29,7 @@ public class FirestoreJobProperties {
     private String externalIdAttrName;
 
     private String queryExtensionBeanName;
+
+    // empty == all
+    private List<String> hashAttributes = new ArrayList<>();
 }

--- a/src/main/java/com/obj/nc/utils/JsonUtils.java
+++ b/src/main/java/com/obj/nc/utils/JsonUtils.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.obj.nc.exceptions.PayloadValidationException;
 import org.springframework.integration.support.json.Jackson2JsonObjectMapper;
@@ -250,6 +251,11 @@ public class JsonUtils {
 		} catch (Exception e) {
 		       return Optional.of(e.getMessage());
 	    }
+	}
+
+	public static ObjectNode createJsonObjectNode() {
+		final ObjectMapper mapper = getObjectMapperWithSortedProperties();
+		return mapper.createObjectNode();
 	}
 	
 	public static JsonNode checkIfJsonValidAndReturn(String eventJson) {

--- a/src/test/java/com/obj/nc/functions/processors/pullNotifDataPersister/PullNotifDataPersisterTest.java
+++ b/src/test/java/com/obj/nc/functions/processors/pullNotifDataPersister/PullNotifDataPersisterTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.obj.nc.domain.pullNotifData.PullNotifDataPersistentState;
 import com.obj.nc.exceptions.PayloadValidationException;
-import com.obj.nc.functions.processors.pullNotifDataPersister.PulledNotificationDataNewAndChangedPersister;
 import com.obj.nc.repositories.PullNotifDataRepository;
 import com.obj.nc.utils.JsonUtils;
 
@@ -30,6 +29,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -40,11 +40,16 @@ public class PullNotifDataPersisterTest {
 
     final String extId1 = "id-1";
     final String extId2 = "id-2";
+    final List<String> extIds12 = Arrays.asList(extId1, extId2);
+    final String extId3 = "id-3";
     final String content1 = "{\"id\" : \"" + extId1 + "\" , \"data\" : 3}";
     final String content1_changed = "{ \"id\": \"" + extId1 + "\" , \"data\" : 3}";
     final String content2 = "{\"id\":\"" + extId2 + "\",\"data\": 3}";
+    final String content3 = "{\"id\":\"" + extId3 + "\",\"data\": 3}";
+    final String content4 = "{\"id\":\"" + extId3 + "\",\"data\": 4}";
     final String content_other = "{\"id\" :\"other\" , \"data\": 3}";
     final String pulledData = "["+content1+","+content2+"]";
+    final String pulledData2 = "["+content4+"]";
     final String invalidJson = "[{\"id-other-name\":\"" + extId1 + "\"}]";
 
     @Test
@@ -70,7 +75,7 @@ public class PullNotifDataPersisterTest {
 
         List<PullNotifDataPersistentState> existingData = Collections.emptyList();
 
-        verifyPersistingProcess(existingData, pulledNotifData, expectPersisted1, expectPersisted2);
+        verifyPersistingProcess(extIds12, existingData, pulledNotifData, expectPersisted1, expectPersisted2);
     }
 
     @Test
@@ -82,7 +87,7 @@ public class PullNotifDataPersisterTest {
 
         List<PullNotifDataPersistentState> existingData = Collections.singletonList(PullNotifDataPersistentState.createFromJson(JsonUtils.readJsonNodeFromJSONString(content_other), "id"));
 
-        verifyPersistingProcess(existingData, pulledNotifData, expectPersisted1, expectPersisted2);
+        verifyPersistingProcess(extIds12, existingData, pulledNotifData, expectPersisted1, expectPersisted2);
     }
 
     @Test
@@ -92,9 +97,9 @@ public class PullNotifDataPersisterTest {
         PullNotifDataPersistentState expectPersisted1 = PullNotifDataPersistentState.createFromJson(JsonUtils.readJsonNodeFromJSONString(content1), "id");
         PullNotifDataPersistentState expectPersisted2 = PullNotifDataPersistentState.createFromJson(JsonUtils.readJsonNodeFromJSONString(content2), "id");
 
-        PullNotifDataPersistentState previous = PullNotifDataPersistentState.createFromJson(JsonUtils.readJsonNodeFromJSONString(content_other), "id");           
+        PullNotifDataPersistentState previous = PullNotifDataPersistentState.createFromJson(JsonUtils.readJsonNodeFromJSONString(content_other), "id");
 
-        verifyPersistingProcess(Collections.singletonList(previous),pulledNotifData, expectPersisted1, expectPersisted2);
+        verifyPersistingProcess(extIds12, Collections.singletonList(previous),pulledNotifData, expectPersisted1, expectPersisted2);
     }
 
     @Test
@@ -103,18 +108,41 @@ public class PullNotifDataPersisterTest {
 
         PullNotifDataPersistentState expectPersisted2 = PullNotifDataPersistentState.createFromJson(JsonUtils.readJsonNodeFromJSONString(content2), "id");
 
-        PullNotifDataPersistentState previous = PullNotifDataPersistentState.createFromJson(JsonUtils.readJsonNodeFromJSONString(content1), "id");           
+        PullNotifDataPersistentState previous = PullNotifDataPersistentState.createFromJson(JsonUtils.readJsonNodeFromJSONString(content1), "id");
 
-        verifyPersistingProcess(Collections.singletonList(previous),pulledNotifData, expectPersisted2);
+        verifyPersistingProcess(extIds12, Collections.singletonList(previous),pulledNotifData, expectPersisted2);
     }
 
-    private void verifyPersistingProcess(List<PullNotifDataPersistentState> storedRecords, List<JsonNode> pulledNotifData, PullNotifDataPersistentState ... expectedPersisted) throws JsonProcessingException {
+    @Test
+    void testPersistingExistingWithAttributesSubset() throws JsonProcessingException {
+        List<JsonNode> pulledNotifData = JsonUtils.readJsonNodeListFromJSONString(pulledData2);
+        // data field will be changed
+        List<String> hashAttributes = Arrays.asList("data");
+
+        PullNotifDataPersistentState expectPersisted = PullNotifDataPersistentState.createFromJson(JsonUtils.readJsonNodeFromJSONString(content4), "id", hashAttributes);
+        PullNotifDataPersistentState previous = PullNotifDataPersistentState.createFromJson(JsonUtils.readJsonNodeFromJSONString(content3), "id", hashAttributes);
+
+        verifyPersistingProcess(Arrays.asList(extId3), Collections.singletonList(previous), pulledNotifData, hashAttributes, expectPersisted);
+    }
+
+    @Test
+    void testNotPersistingExistingWithAttributesSubset() throws JsonProcessingException {
+        List<JsonNode> pulledNotifData = JsonUtils.readJsonNodeListFromJSONString(pulledData2);
+        // id field will not be changed
+        List<String> hashAttributes = Arrays.asList("id");
+
+        PullNotifDataPersistentState previous = PullNotifDataPersistentState.createFromJson(JsonUtils.readJsonNodeFromJSONString(content3), "id", hashAttributes);
+
+        verifyPersistingProcess(Arrays.asList(extId3), Collections.singletonList(previous), pulledNotifData, hashAttributes);
+    }
+
+    private void verifyPersistingProcess(List<String> extIds, List<PullNotifDataPersistentState> storedRecords, List<JsonNode> pulledNotifData, List<String> hashAttributes, PullNotifDataPersistentState ... expectedPersisted) throws JsonProcessingException {
         // given
-        Mockito.when(repo.findAllHashesByExternalId(Arrays.asList(extId1, extId2))).thenReturn(storedRecords);
+        Mockito.when(repo.findAllHashesByExternalId(extIds)).thenReturn(storedRecords);
         Mockito.when(repo.saveAll(ArgumentMatchers.any())).thenAnswer(a -> a.getArgument(0));
 
         // when
-        PulledNotificationDataNewAndChangedPersister persister = new PulledNotificationDataNewAndChangedPersister(repo, "id");
+        PulledNotificationDataNewAndChangedPersister persister = new PulledNotificationDataNewAndChangedPersister(repo, "id", hashAttributes);
         List<JsonNode> notifDataNewAndChanged = persister.apply(pulledNotifData);
 
         // then
@@ -122,7 +150,7 @@ public class PullNotifDataPersisterTest {
         Assertions.assertEquals(expectedPersisted.length, notifDataNewAndChanged.size());
 
         //all input notifs have been checked
-        Mockito.verify(repo).findAllHashesByExternalId(Arrays.asList(extId1, extId2));
+        Mockito.verify(repo).findAllHashesByExternalId(extIds);
 
         //all new and changed have been persisted
         ArgumentCaptor<List<PullNotifDataPersistentState>> newAndChangedCaptor = ArgumentCaptor.forClass(List.class);
@@ -134,6 +162,10 @@ public class PullNotifDataPersisterTest {
         for (int i =0; i< expectedPersisted.length; i++) {
             assertEquals(expectedPersisted[i], newAndChanged.get(i));
         }
+    }
+
+    private void verifyPersistingProcess(List<String> extIds, List<PullNotifDataPersistentState> storedRecords, List<JsonNode> pulledNotifData, PullNotifDataPersistentState ... expectedPersisted) throws JsonProcessingException {
+        verifyPersistingProcess(extIds, storedRecords, pulledNotifData, new ArrayList<>(), expectedPersisted);
     }
 
     private void assertEquals(PullNotifDataPersistentState expected, PullNotifDataPersistentState actual) {


### PR DESCRIPTION
rozsirenie filtrovania delty novych pullnutych dat o moznost zadefinovat v configu jobu list atributov _hashAttributes_, podla ktorych sa delta pocita,

napr.: job pullne list objektov typu Kandidat s atributmi email, meno, ovladane_jazyky:
- ak by si napr. Kandidat pridal po case novy jazyk do ovladane_jazyky, tak by bol novym kandidatom, lebo vypocet hashu by bral do uvahy vsetky atributy vratane ovladane_jazyky a to je problem
- chcem brat teda do uvahy iba Kandidatov atribut email, aby som na rovnaky email neposlal 2 krat rovnaku message 
- ak v configu jobu nevyplnim ziadne _hashAttributes_, tak sa hash pocita zo vsetkych atributov
- ak vyplnim do _hashAttributes_ atributy, ktore pullnute data nemaju, tak kandidatovu spravu neposlem ale hodim exception, pretoze som mohol spravit preklep a poslalo by to kvoli tomu niekomu viac krat rovnaku message