### PR TITLE
add additional recipients to event summary email message, filter even…

### DIFF
--- a/src/main/java/com/obj/nc/controllers/TestDataRestController.java
+++ b/src/main/java/com/obj/nc/controllers/TestDataRestController.java
@@ -19,6 +19,9 @@
 
 package com.obj.nc.controllers;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.obj.nc.domain.content.email.EmailContent;
@@ -50,6 +53,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import lombok.EqualsAndHashCode;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -62,6 +66,8 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
+import static com.obj.nc.controllers.TestDataRestController.BaseDummyEventPayload.DUMMY_PAYLOAD_TYPE;
 import static com.obj.nc.functions.processors.deliveryInfo.domain.DeliveryInfo.DELIVERY_STATUS.FAILED;
 import static com.obj.nc.functions.processors.deliveryInfo.domain.DeliveryInfo.DELIVERY_STATUS.PROCESSING;
 import static com.obj.nc.functions.processors.deliveryInfo.domain.DeliveryInfo.DELIVERY_STATUS.SENT;
@@ -500,20 +506,29 @@ public class TestDataRestController {
         return Instant.ofEpochSecond(random);
     }
     
+
+    @Data
+    @JsonTypeInfo(use = NAME)
+    @JsonSubTypes({
+            @Type(value = DummyEventPayload.class, name = DUMMY_PAYLOAD_TYPE)
+    })
+    @NoArgsConstructor
+    static abstract class BaseDummyEventPayload {
+        public static final String DUMMY_PAYLOAD_TYPE = "A";
+    }
+
     @Data
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
-    static class DummyEventPayload {
-    
+    @EqualsAndHashCode(callSuper = true)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class DummyEventPayload extends BaseDummyEventPayload {
         String stringField;
         Long longField;
-        
+
         JsonNode toJsonNode() {
             return JsonUtils.readJsonNodeFromPojo(this);
         }
-        
     }
-    
 }

--- a/src/main/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationProperties.java
+++ b/src/main/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationProperties.java
@@ -19,8 +19,11 @@
 
 package com.obj.nc.flows.eventSummaryNotification;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -47,5 +50,16 @@ public class EventSummaryNotificationProperties {
     private List<String> emailRecipients; 
     
     private String emailTemplateFileName = "event-summary.html";
+
+    private List<AdditionalEmailRecipient> additionalEmailRecipients = new ArrayList<>();
+
+    @Getter
+    @Setter
+    public static class AdditionalEmailRecipient {
+        private String email;
+
+        // nc.flows.event-summary-notif.additional-email-recipients[0].event-spel-filter-expression={'A','B','C'}.contains(#jsonPath(payloadJson.toString(), '$.@type'))
+        private String eventSpelFilterExpression;
+    }
 
 }

--- a/src/main/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationProperties.java
+++ b/src/main/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationProperties.java
@@ -56,7 +56,7 @@ public class EventSummaryNotificationProperties {
     @Getter
     @Setter
     public static class AdditionalEmailRecipient {
-        private String email;
+        private List<String> emails;
 
         // nc.flows.event-summary-notif.additional-email-recipients[0].event-spel-filter-expression={'A','B','C'}.contains(#jsonPath(payloadJson.toString(), '$.@type'))
         private String eventSpelFilterExpression;

--- a/src/main/java/com/obj/nc/flows/eventSummaryNotification/ProcessedEventsToSummaryMailConverter.java
+++ b/src/main/java/com/obj/nc/flows/eventSummaryNotification/ProcessedEventsToSummaryMailConverter.java
@@ -79,8 +79,14 @@ public class ProcessedEventsToSummaryMailConverter implements PullNotifData2Noti
 
 		for (AdditionalEmailRecipient additionalRecipient : properties.getAdditionalEmailRecipients()) {
 			String spelFilterExpression = additionalRecipient.getEventSpelFilterExpression();
+
 			if (eventMatchesExpression(event, spelFilterExpression)) {
-				recipients.add(new EmailEndpoint(additionalRecipient.getEmail()));
+				List<EmailEndpoint> additionalRecipientEndpoints = additionalRecipient
+						.getEmails().stream()
+						.map(EmailEndpoint::new)
+						.collect(Collectors.toList());
+
+				recipients.addAll(additionalRecipientEndpoints);
 			}
 		}
 

--- a/src/main/java/com/obj/nc/functions/processors/spelFilter/SpelFilterPojo.java
+++ b/src/main/java/com/obj/nc/functions/processors/spelFilter/SpelFilterPojo.java
@@ -20,17 +20,20 @@ package com.obj.nc.functions.processors.spelFilter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.obj.nc.aspects.DocumentProcessingInfo;
 import com.obj.nc.exceptions.ProcessingException;
 import com.obj.nc.functions.processors.ProcessorFunctionAdapter;
 
+import org.springframework.beans.BeanUtils;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.integration.json.JsonPathUtils;
 
 @Slf4j
 @DocumentProcessingInfo("SpelFilterPojo")
@@ -50,6 +53,8 @@ public class SpelFilterPojo<T> extends ProcessorFunctionAdapter<List<T>, List<T>
         for (T payload: payloads) {
             StandardEvaluationContext context = new StandardEvaluationContext();
             context.setRootObject(payload);
+
+            context.registerFunction("jsonPath", Objects.requireNonNull(BeanUtils.resolveSignature("evaluate", JsonPathUtils.class)));
 
             Object value = expression.getValue(context);
 

--- a/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationWithAdditionalRecipientShouldFailTest.java
+++ b/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationWithAdditionalRecipientShouldFailTest.java
@@ -1,0 +1,94 @@
+package com.obj.nc.flows.eventSummaryNotification;
+
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import com.obj.nc.controllers.TestDataRestController;
+import com.obj.nc.domain.event.GenericEvent;
+import com.obj.nc.flows.dataSources.http.HttpDatasourceNameCreator;
+import com.obj.nc.repositories.GenericEventRepository;
+import com.obj.nc.testUtils.BaseIntegrationTest;
+import com.obj.nc.testUtils.SystemPropertyActiveProfileResolver;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
+import org.springframework.integration.test.context.SpringIntegrationTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.mail.internet.MimeMessage;
+
+import static com.obj.nc.flows.inputEventRouting.config.InputEventRoutingFlowConfig.GENERIC_EVENT_CHANNEL_ADAPTER_BEAN_NAME;
+import static org.junit.Assert.assertEquals;
+
+@ActiveProfiles(value = {"test"}, resolver = SystemPropertyActiveProfileResolver.class)
+@SpringIntegrationTest(noAutoStartup = GENERIC_EVENT_CHANNEL_ADAPTER_BEAN_NAME)
+@SpringBootTest(
+        webEnvironment = WebEnvironment.DEFINED_PORT,
+        properties = {
+                "nc.flows.event-summary-notif.event-selection=ALL_EVENT",
+                "nc.flows.event-summary-notif.seconds-since-last-processing=1",
+                "nc.flows.event-summary-notif.cron=*/12 * * * * *",
+                "nc.flows.event-summary-notif.email_recipients[0]=cuzy@objectify.sk",
+                "nc.flows.event-summary-notif.additional-email-recipients[0].email=bazik@objectify.sk",
+                // {'B','C'} does not contain 'A' => should fail
+                "nc.flows.event-summary-notif.additional-email-recipients[0].event-spel-filter-expression={'B','C'}.contains(#jsonPath(payloadJson.toString(), '$.@type'))"
+        }
+)
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
+//this test register programmatically spring integration flows. it seems to confuse the spring context management in tests
+@Slf4j
+class EventSummaryNotificationWithAdditionalRecipientShouldFailTest extends BaseIntegrationTest {
+    private @Autowired JdbcTemplate springJdbcTemplate;
+    private @Autowired TestDataRestController testDataController;
+    private @Autowired GenericEventRepository eventRepo;
+    private @Autowired @Qualifier(DATA_SOURCE_POLLER_NAME) SourcePollingChannelAdapter pollAbleSourceHttp;
+
+    public static final String DATA_SOURCE_POLLER_NAME =
+            HttpDatasourceNameCreator.PULL_HTTP_DS_NAME_PREFIX +
+                    EventSummaryNotificationProperties.EVENT_SUMMARY_DS_NAME +
+                    HttpDatasourceNameCreator.PULL_HTTP_DS_JOB_POSTFIX +
+                    HttpDatasourceNameCreator.PULL_HTTP_DS_POLLER_POSTFIX;
+
+    @BeforeEach
+    public void setupDbs() {
+        purgeNotifTables(springJdbcTemplate);
+        pollAbleSourceHttp.start();
+    }
+
+    @AfterEach
+    public void tearDownDbs() {
+        pollAbleSourceHttp.stop();
+    }
+
+    @Test
+    void testDataPulledAndMessageSent() {
+        // when
+        GenericEvent testEvent = testDataController.persistFullEventProcessingData();
+        testEvent.setNotifyAfterProcessing(true);
+        eventRepo.save(testEvent);
+        springJdbcTemplate.update("update nc_delivery_info set processed_on = now() - INTERVAL '1 min'");
+
+        //then
+        boolean received = greenMail.waitForIncomingEmail(15000L, 2);   //this test can take some time
+        assertEquals(false, received);
+        assertEquals(1, greenMail.getReceivedMessages().length);
+        MimeMessage[] receivedMessage = greenMail.getReceivedMessages();
+        assertMessagesSendTo(receivedMessage, "cuzy@objectify.sk", 1);
+    }
+
+    @RegisterExtension
+    static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP)
+            .withConfiguration(GreenMailConfiguration.aConfig().withUser("no-reply@objectify.sk", "xxx"))
+            .withPerMethodLifecycle(false);
+
+}

--- a/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationWithAdditionalRecipientShouldFailTest.java
+++ b/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationWithAdditionalRecipientShouldFailTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertEquals;
                 "nc.flows.event-summary-notif.seconds-since-last-processing=1",
                 "nc.flows.event-summary-notif.cron=*/12 * * * * *",
                 "nc.flows.event-summary-notif.email_recipients[0]=cuzy@objectify.sk",
-                "nc.flows.event-summary-notif.additional-email-recipients[0].email=bazik@objectify.sk",
+                "nc.flows.event-summary-notif.additional-email-recipients[0].emails=bazik@objectify.sk,bazik2@objectify.sk",
                 // {'B','C'} does not contain 'A' => should fail
                 "nc.flows.event-summary-notif.additional-email-recipients[0].event-spel-filter-expression={'B','C'}.contains(#jsonPath(payloadJson.toString(), '$.@type'))"
         }
@@ -79,7 +79,7 @@ class EventSummaryNotificationWithAdditionalRecipientShouldFailTest extends Base
         springJdbcTemplate.update("update nc_delivery_info set processed_on = now() - INTERVAL '1 min'");
 
         //then
-        boolean received = greenMail.waitForIncomingEmail(15000L, 2);   //this test can take some time
+        boolean received = greenMail.waitForIncomingEmail(15000L, 3);   //this test can take some time
         assertEquals(false, received);
         assertEquals(1, greenMail.getReceivedMessages().length);
         MimeMessage[] receivedMessage = greenMail.getReceivedMessages();

--- a/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationWithAdditionalRecipientShouldPassTest.java
+++ b/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationWithAdditionalRecipientShouldPassTest.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertEquals;
                 "nc.flows.event-summary-notif.seconds-since-last-processing=1",
                 "nc.flows.event-summary-notif.cron=*/12 * * * * *",
                 "nc.flows.event-summary-notif.email_recipients[0]=cuzy@objectify.sk",
-                "nc.flows.event-summary-notif.additional-email-recipients[0].email=bazik@objectify.sk",
+                "nc.flows.event-summary-notif.additional-email-recipients[0].emails=bazik@objectify.sk,bazik2@objectify.sk",
                 // {'A','B','C'} contains 'A' => should pass
                 "nc.flows.event-summary-notif.additional-email-recipients[0].event-spel-filter-expression={'A','B','C'}.contains(#jsonPath(payloadJson.toString(), '$.@type'))"
         }
@@ -79,13 +79,14 @@ class EventSummaryNotificationWithAdditionalRecipientShouldPassTest extends Base
         springJdbcTemplate.update("update nc_delivery_info set processed_on = now() - INTERVAL '1 min'");
 
         //then
-        boolean received = greenMail.waitForIncomingEmail(15000L, 2);   //this test can take some time
+        boolean received = greenMail.waitForIncomingEmail(15000L, 3);   //this test can take some time
         assertEquals(true, received);
-        assertEquals(2, greenMail.getReceivedMessages().length);
+        assertEquals(3, greenMail.getReceivedMessages().length);
 
         MimeMessage[] receivedMessage = greenMail.getReceivedMessages();
         assertMessagesSendTo(receivedMessage, "cuzy@objectify.sk", 1);
         assertMessagesSendTo(receivedMessage, "bazik@objectify.sk", 1);
+        assertMessagesSendTo(receivedMessage, "bazik2@objectify.sk", 1);
     }
 
     @RegisterExtension

--- a/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationWithAdditionalRecipientShouldPassTest.java
+++ b/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationWithAdditionalRecipientShouldPassTest.java
@@ -1,0 +1,96 @@
+package com.obj.nc.flows.eventSummaryNotification;
+
+import com.icegreen.greenmail.configuration.GreenMailConfiguration;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
+import com.icegreen.greenmail.util.ServerSetupTest;
+import com.obj.nc.controllers.TestDataRestController;
+import com.obj.nc.domain.event.GenericEvent;
+import com.obj.nc.flows.dataSources.http.HttpDatasourceNameCreator;
+import com.obj.nc.repositories.GenericEventRepository;
+import com.obj.nc.testUtils.BaseIntegrationTest;
+import com.obj.nc.testUtils.SystemPropertyActiveProfileResolver;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
+import org.springframework.integration.test.context.SpringIntegrationTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.mail.internet.MimeMessage;
+
+import static com.obj.nc.flows.inputEventRouting.config.InputEventRoutingFlowConfig.GENERIC_EVENT_CHANNEL_ADAPTER_BEAN_NAME;
+import static org.junit.Assert.assertEquals;
+
+@ActiveProfiles(value = {"test"}, resolver = SystemPropertyActiveProfileResolver.class)
+@SpringIntegrationTest(noAutoStartup = GENERIC_EVENT_CHANNEL_ADAPTER_BEAN_NAME)
+@SpringBootTest(
+        webEnvironment = WebEnvironment.DEFINED_PORT,
+        properties = {
+                "nc.flows.event-summary-notif.event-selection=ALL_EVENT",
+                "nc.flows.event-summary-notif.seconds-since-last-processing=1",
+                "nc.flows.event-summary-notif.cron=*/12 * * * * *",
+                "nc.flows.event-summary-notif.email_recipients[0]=cuzy@objectify.sk",
+                "nc.flows.event-summary-notif.additional-email-recipients[0].email=bazik@objectify.sk",
+                // {'A','B','C'} contains 'A' => should pass
+                "nc.flows.event-summary-notif.additional-email-recipients[0].event-spel-filter-expression={'A','B','C'}.contains(#jsonPath(payloadJson.toString(), '$.@type'))"
+        }
+)
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
+//this test register programmatically spring integration flows. it seems to confuse the spring context management in tests
+@Slf4j
+class EventSummaryNotificationWithAdditionalRecipientShouldPassTest extends BaseIntegrationTest {
+    private @Autowired JdbcTemplate springJdbcTemplate;
+    private @Autowired TestDataRestController testDataController;
+    private @Autowired GenericEventRepository eventRepo;
+    private @Autowired @Qualifier(DATA_SOURCE_POLLER_NAME) SourcePollingChannelAdapter pollAbleSourceHttp;
+
+    public static final String DATA_SOURCE_POLLER_NAME =
+            HttpDatasourceNameCreator.PULL_HTTP_DS_NAME_PREFIX +
+                    EventSummaryNotificationProperties.EVENT_SUMMARY_DS_NAME +
+                    HttpDatasourceNameCreator.PULL_HTTP_DS_JOB_POSTFIX +
+                    HttpDatasourceNameCreator.PULL_HTTP_DS_POLLER_POSTFIX;
+
+    @BeforeEach
+    public void setupDbs() {
+        purgeNotifTables(springJdbcTemplate);
+        pollAbleSourceHttp.start();
+    }
+
+    @AfterEach
+    public void tearDownDbs() {
+        pollAbleSourceHttp.stop();
+    }
+
+    @Test
+    void testDataPulledAndMessageSent() {
+        // when
+        GenericEvent testEvent = testDataController.persistFullEventProcessingData();
+        testEvent.setNotifyAfterProcessing(true);
+        eventRepo.save(testEvent);
+        springJdbcTemplate.update("update nc_delivery_info set processed_on = now() - INTERVAL '1 min'");
+
+        //then
+        boolean received = greenMail.waitForIncomingEmail(15000L, 2);   //this test can take some time
+        assertEquals(true, received);
+        assertEquals(2, greenMail.getReceivedMessages().length);
+
+        MimeMessage[] receivedMessage = greenMail.getReceivedMessages();
+        assertMessagesSendTo(receivedMessage, "cuzy@objectify.sk", 1);
+        assertMessagesSendTo(receivedMessage, "bazik@objectify.sk", 1);
+    }
+
+    @RegisterExtension
+    static GreenMailExtension greenMail = new GreenMailExtension(ServerSetupTest.SMTP)
+            .withConfiguration(GreenMailConfiguration.aConfig().withUser("no-reply@objectify.sk", "xxx"))
+            .withPerMethodLifecycle(false);
+
+}


### PR DESCRIPTION
registrovanie noveho pull flowu prinasalo komplikacie, napr. converter bean "per pull flow", dvojite (pripadne 3 alebo aj viac-ite) spracovavanie toho isteho eventu - pre kazdy flow,.. momentalne aj select eventov z DB predpoklada, ze sa event spracuje iba raz 

nakoniec pri jedinom spracovani eventov iba dodatocne pridame prijemcov spravy (ak event matche ich SpEL expression), tj. ak je napr. event FTTH, tak okrem hlavnych prijemcov sumaru prejdeme este cez vsetkcyh additionalRecipients (config property) a ak event matchne ich podmienku ("chceme prijimat FTTH event sumare") tak ich pridame do prijemcov