### PR TITLE
fix latest delivery infos

### DIFF
--- a/src/main/java/com/obj/nc/controllers/DeliveryInfoRestController.java
+++ b/src/main/java/com/obj/nc/controllers/DeliveryInfoRestController.java
@@ -81,7 +81,7 @@ public class DeliveryInfoRestController {
 		UUID endpointUUID = endpointId == null ? null : UUID.fromString(endpointId);
 
 		long total = deliveryRepo.countByEventIdAndEndpointId(UUID.fromString(eventId), endpointUUID);
-		List<DeliveryInfo> deliveries = deliveryRepo.findByEventIdAndEndpointIdOrderByProcessedOn(
+		List<DeliveryInfo> deliveries = deliveryRepo.findLatestByEventIdAndEndpointIdOrderByProcessedOn(
 				UUID.fromString(eventId), endpointUUID, pageable.getPageSize(), pageable.getOffset());
 
 		if (deliveries.isEmpty()) {

--- a/src/main/java/com/obj/nc/controllers/EventsRestController.java
+++ b/src/main/java/com/obj/nc/controllers/EventsRestController.java
@@ -147,9 +147,10 @@ public class EventsRestController {
 
 	@GetMapping(value = "/summary-notification", produces = APPLICATION_JSON_VALUE)
 	public List<GenericEvent> findEventsForSummaryNotification() {
+		int secondsSinceLastProcessing = summaryNotifProps.getSecondsSinceLastProcessing();
 		Instant now = LocalDateTime.now().toInstant(ZoneOffset.ofTotalSeconds(0));
 		Instant before = now.minus(deliveryStatusTrackingProperties.getMaxAgeOfUnfinishedDeliveriesInDays(), ChronoUnit.DAYS);
-		List<GenericEvent> events = eventsRepository.findEventsForSummaryNotification(before);
+		List<GenericEvent> events = eventsRepository.findEventsForSummaryNotification(secondsSinceLastProcessing, before);
 		return events;
 	}
 }

--- a/src/main/java/com/obj/nc/controllers/EventsRestController.java
+++ b/src/main/java/com/obj/nc/controllers/EventsRestController.java
@@ -151,10 +151,9 @@ public class EventsRestController {
 //		GenericEvent start = eventsRepository.findByExternalId("74514-start");
 //		GenericEvent end = eventsRepository.findByExternalId("74514-end");
 //		return Arrays.asList(start, end);
-		int secondsSinceLastProcessing = summaryNotifProps.getSecondsSinceLastProcessing();
 		Instant now = LocalDateTime.now().toInstant(ZoneOffset.ofTotalSeconds(0));
-		Instant period = now.minus(deliveryStatusTrackingProperties.getMaxAgeOfUnfinishedDeliveriesInDays(), ChronoUnit.DAYS);
-		List<GenericEvent> events = eventsRepository.findEventsForSummaryNotification(secondsSinceLastProcessing, period);
+		Instant before = now.minus(deliveryStatusTrackingProperties.getMaxAgeOfUnfinishedDeliveriesInDays(), ChronoUnit.DAYS);
+		List<GenericEvent> events = eventsRepository.findEventsForSummaryNotification(before);
 		return events;
 	}
 }

--- a/src/main/java/com/obj/nc/controllers/EventsRestController.java
+++ b/src/main/java/com/obj/nc/controllers/EventsRestController.java
@@ -147,10 +147,6 @@ public class EventsRestController {
 
 	@GetMapping(value = "/summary-notification", produces = APPLICATION_JSON_VALUE)
 	public List<GenericEvent> findEventsForSummaryNotification() {
-		//TODO remove after testing
-//		GenericEvent start = eventsRepository.findByExternalId("74514-start");
-//		GenericEvent end = eventsRepository.findByExternalId("74514-end");
-//		return Arrays.asList(start, end);
 		Instant now = LocalDateTime.now().toInstant(ZoneOffset.ofTotalSeconds(0));
 		Instant before = now.minus(deliveryStatusTrackingProperties.getMaxAgeOfUnfinishedDeliveriesInDays(), ChronoUnit.DAYS);
 		List<GenericEvent> events = eventsRepository.findEventsForSummaryNotification(before);

--- a/src/main/java/com/obj/nc/domain/dto/DeliveryStatsByEndpointType.java
+++ b/src/main/java/com/obj/nc/domain/dto/DeliveryStatsByEndpointType.java
@@ -42,7 +42,6 @@ public class DeliveryStatsByEndpointType {
     private long messagesDeliveryPendingCount;
     private long messagesDeliveryUnknownCount;
     private long messagesDeliveryFailedCount;
-    private long messagesProcessingCount;
     private long messagesDiscardedCount;
 
     public static class DeliveryStatsByEndpointTypeRowMapper implements RowMapper<DeliveryStatsByEndpointType> {
@@ -61,7 +60,6 @@ public class DeliveryStatsByEndpointType {
                     .messagesDeliveryPendingCount(resultSet.getLong("messages_delivery_pending_count"))
                     .messagesDeliveryUnknownCount(resultSet.getLong("messages_delivery_unknown_count"))
                     .messagesDeliveryFailedCount(resultSet.getLong("messages_delivery_failed_count"))
-                    .messagesProcessingCount(resultSet.getLong("messages_processing_count"))
                     .messagesDiscardedCount(resultSet.getLong("messages_discarded_count"))
                     .build();
             

--- a/src/main/java/com/obj/nc/repositories/DeliveryInfoRepository.java
+++ b/src/main/java/com/obj/nc/repositories/DeliveryInfoRepository.java
@@ -77,20 +77,20 @@ public interface DeliveryInfoRepository extends PagingAndSortingRepository<Deliv
 
     String WITH_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID =
         "with latest_msg_di as (\n" +
-        "    select di.status, di.message_id as message_id, MAX(di.processed_on) as processed_on\n" +
+        "    select distinct on (di.message_id) di.id as delivery_id\n" +
         "    from nc_delivery_info di join nc_message m on di.message_id = m.id\n" +
         "    where :eventId = ANY (m.previous_event_ids)\n" +
-        "    and ((:endpointId)::uuid is null or endpoint_id = (:endpointId)::uuid)\n" +
-        "    and di.status IN ('SENT', 'FAILED', 'DELIVERED', 'DELIVERY_UNKNOWN', 'DELIVERY_FAILED', 'DELIVERY_PENDING')\n" +
-        "    GROUP BY di.status, di.message_id\n" +
+        "      and ((:endpointId)::uuid is null or endpoint_id = (:endpointId)::uuid)\n" +
+        "      and di.status IN ('SENT', 'FAILED', 'DELIVERED', 'DELIVERY_UNKNOWN', 'DELIVERY_FAILED', 'DELIVERY_PENDING')\n" +
+        "    order by di.message_id, di.processed_on desc\n" +
         ")\n";
 
     String QRY_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID = WITH_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID +
             "select di.*\n" +
             "from nc_delivery_info di\n" +
-            "join latest_msg_di latest on latest.message_id = di.message_id and latest.processed_on = di.processed_on and latest.status = di.status\n" +
+            "join latest_msg_di latest on latest.delivery_id = di.id\n" +
             "order by processed_on\n" +
-            "limit :size offset :offset";
+            "limit :size offset :offset\n";
 
     @Query(QRY_LATEST_DELIVERY_INFO_BY_ENDPOINT_ID)
     List<DeliveryInfo> findLatestByEventIdAndEndpointIdOrderByProcessedOn(@Param("eventId") UUID eventId,

--- a/src/main/java/com/obj/nc/repositories/DeliveryInfoRepository.java
+++ b/src/main/java/com/obj/nc/repositories/DeliveryInfoRepository.java
@@ -186,7 +186,7 @@ public interface DeliveryInfoRepository extends PagingAndSortingRepository<Deliv
                 "   select 1 " +
                 "   from nc_delivery_info di2 " +
                 "   where di.message_id = di2.message_id " +
-                "   and di2.status IN ('FAILED', 'DISCARDED', 'DELIVERED', 'DELIVERY_FAILED', 'DELIVERY_UNKNOWN', 'READ')" +
+                "   and di2.status NOT IN ('PROCESSING', 'SENT', 'DELIVERY_PENDING')" +
                 ") " +
                 "order by m.id, di.processed_on desc",
         rowMapperClass = DeliveryInfoDtoMapper.class

--- a/src/main/java/com/obj/nc/repositories/GenericEventRepository.java
+++ b/src/main/java/com/obj/nc/repositories/GenericEventRepository.java
@@ -86,42 +86,38 @@ public interface GenericEventRepository extends PagingAndSortingRepository<Gener
 													   @Param("offset") long offset,
 													   @Param("pageSize") int pageSize);
 	@Query(
-		value = 
-			"select " +
-			"	msg_with_endp.endpoint_type, " + 
-			"	count(distinct msg_with_endp.message_id) as messages_count,  " + 
-			"	count(distinct msg_with_endp.endpoint_id) as endpoints_count,  " + 
-			"	count(distinct di.id) filter(where di.status = 'SENT') as messages_sent_count,  " + 
-			"	count(distinct di.id) filter(where di.status = 'READ') as messages_read_count,  " + 
-			"	count(distinct di.id) filter(where di.status = 'FAILED') as messages_failed_count,  " +
-			"	count(distinct di.id) filter(where di.status = 'DELIVERED') as messages_delivered_count, " +
-			"	count(distinct di.id) filter(where di.status = 'DELIVERY_PENDING') as messages_delivery_pending_count, " +
-			"	count(distinct di.id) filter(where di.status = 'DELIVERY_UNKNOWN') as messages_delivery_unknown_count, " +
-			"	count(distinct di.id) filter(where di.status = 'DELIVERY_FAILED') as messages_delivery_failed_count, " +
-			"	count(distinct di.id) filter(where di.status = 'PROCESSING') as messages_processing_count, " +
-			"	count(distinct di.id) filter(where di.status = 'DISCARDED') as messages_discarded_count " +
-			"from  " + 
-			"	nc_event e  " + 
-			"left join (  " + 
-			"	select  " + 
-			"		msg.*,  " + 
-			"		m2e.message_id as message_id, " + 
-			"		m2e.endpoint_id as endpoint_id, " + 
-			"		ep.endpoint_type  " + 
-			"	from nc_message msg  " + 
-			"	inner join nc_message_2_endpoint_rel m2e on ( m2e.message_id = msg.id ) " + 
-			"	inner join nc_endpoint ep on ep.id = m2e.endpoint_id  " + 
-			") msg_with_endp on ( e.id = any( msg_with_endp.previous_event_ids )) " + 
-			"left join  " + 
-			"	nc_delivery_info di on di.message_id = msg_with_endp.id  " + 
-			"where  " +
-			"	e.id = (:eventId)::uuid " +
-					"and di.status IN ('SENT', 'FAILED', 'READ', 'DELIVERED', 'DELIVERY_PENDING', 'DELIVERY_UNKNOWN', 'DELIVERY_FAILED', 'PROCESSING', 'DISCARDED')  " +
-					"and message_class NOT LIKE '%Templated'" +
+		value =
+			"with latest_msg_di as (\n" +
+			"    select di.message_id as message_id, di.status, MAX(di.processed_on) as processed_on\n" +
+			"    from nc_delivery_info di\n" +
+			"    join nc_message m on di.message_id = m.id\n" +
+			"    where di.status != 'PROCESSING'\n" +
+			"    GROUP BY di.message_id, di.status\n" +
+			")\n" +
+			"select msg_with_endp.endpoint_type,\n" +
+			"       count(msg_with_endp.message_id)                                    as messages_count,\n" +
+			"       count(distinct msg_with_endp.endpoint_id)                          as endpoints_count,\n" +
+			"       count(di.message_id) filter (where di.status = 'SENT')             as messages_sent_count,\n" +
+			"       count(di.message_id) filter (where di.status = 'READ')             as messages_read_count,\n" +
+			"       count(di.message_id) filter (where di.status = 'FAILED')           as messages_failed_count,\n" +
+			"       count(di.message_id) filter (where di.status = 'DELIVERED')        as messages_delivered_count,\n" +
+			"       count(di.message_id) filter (where di.status = 'DELIVERY_PENDING') as messages_delivery_pending_count,\n" +
+			"       count(di.message_id) filter (where di.status = 'DELIVERY_UNKNOWN') as messages_delivery_unknown_count,\n" +
+			"       count(di.message_id) filter (where di.status = 'DELIVERY_FAILED')  as messages_delivery_failed_count,\n" +
+			"       count(di.message_id) filter (where di.status = 'DISCARDED')        as messages_discarded_count\n" +
+			"from nc_event e\n" +
+			"    left join (select msg.*, m2e.message_id as message_id, m2e.endpoint_id as endpoint_id, ep.endpoint_type\n" +
+			"        from nc_message msg\n" +
+			"            inner join nc_message_2_endpoint_rel m2e on (m2e.message_id = msg.id)\n" +
+			"            inner join nc_endpoint ep on ep.id = m2e.endpoint_id) msg_with_endp\n" +
+			"        on (e.id = any (msg_with_endp.previous_event_ids))\n" +
+			"    left join latest_msg_di di on di.message_id = msg_with_endp.id\n" +
+			"where e.id = (:eventId)::uuid\n" +
+			"  and message_class NOT LIKE '%Templated'\n" +
 			"group by msg_with_endp.endpoint_type",
 		rowMapperClass = DeliveryStatsByEndpointTypeRowMapper.class
-	)						
-	List<DeliveryStatsByEndpointType> findEventStatsByEndpointType(@Param("eventId") UUID eventId);						   
+	)
+	List<DeliveryStatsByEndpointType> findEventStatsByEndpointType(@Param("eventId") UUID eventId);
 	
 	@Query(
 			value = "select " +
@@ -136,13 +132,34 @@ public interface GenericEventRepository extends PagingAndSortingRepository<Gener
 								 @Param("consumedTo") Instant consumedTo,
 								 @Param("eventId") UUID eventId);
 
-    @Query(
-	"select e.id,e.flow_id,e.external_id, e.payload_json,e.time_created,e.time_consumed, e.payload_type, e.notify_after_processing, e.name, e.description " +
-	"from nc_event e " +
-	"	join nc_message m on (e.id  = ANY(m.previous_event_ids)) " +
-	"	join nc_delivery_info di on (di.message_id = m.id ) " +
-	"where notify_after_processing = true " +
-	"group by 1,2,3,4,5,6,7,8,9,10 " +
-	"having max(di.processed_on) < :timestamp")
-    List<GenericEvent> findEventsForSummaryNotification(@Param("timestamp") Instant timestamp);
+	// target event for summary notification is either too old in terms of latest delivery info or sending of all its messages has been completed
+	// in these cases the delivery info of any event's message shouldn't change anymore
+	@Query(
+		"select e.id,e.flow_id,e.external_id, e.payload_json,e.time_created,e.time_consumed, e.payload_type, e.notify_after_processing, e.name, e.description\n" +
+		"from nc_event e\n" +
+		"    join nc_message m on (e.id  = ANY(m.previous_event_ids))\n" +
+		"    join nc_delivery_info di on (di.message_id = m.id )\n" +
+		"where notify_after_processing = true\n" +
+		"group by 1,2,3,4,5,6,7,8,9,10\n" +
+		"having max(di.processed_on) < :timestamp\n" +
+		"union (\n" +
+		"    with latest_msg_di as (\n" +
+		"        select di.message_id as message_id, di.status, MAX(di.processed_on) as processed_on\n" +
+		"        from nc_delivery_info di\n" +
+		"                 join nc_message m on di.message_id = m.id\n" +
+		"        where di.status != 'PROCESSING'\n" +
+		"        GROUP BY di.message_id, di.status\n" +
+		"    )\n" +
+		"    select e.id,e.flow_id,e.external_id, e.payload_json,e.time_created,e.time_consumed, e.payload_type, e.notify_after_processing, e.name, e.description\n" +
+		"    from nc_event e\n" +
+		"             join nc_message m on (e.id  = ANY(m.previous_event_ids))\n" +
+		"             join latest_msg_di di on (di.message_id = m.id )\n" +
+		"    where notify_after_processing = true\n" +
+		"    group by 1,2,3,4,5,6,7,8,9,10\n" +
+		"    having max(di.processed_on) < NOW() - make_interval(secs  => :secondsSinceLastProcessing)\n" +
+			"and count(di.message_id) filter (where di.status != 'DELIVERY_PENDING') = count(di.message_id)\n" +
+		")\n"
+	)
+	List<GenericEvent> findEventsForSummaryNotification(@Param("secondsSinceLastProcessing") int secondsSinceLastProcessing,
+														@Param("timestamp") Instant timestamp);
 }

--- a/src/main/java/com/obj/nc/repositories/GenericEventRepository.java
+++ b/src/main/java/com/obj/nc/repositories/GenericEventRepository.java
@@ -142,8 +142,9 @@ public interface GenericEventRepository extends PagingAndSortingRepository<Gener
 	"	join nc_message m on (e.id  = ANY(m.previous_event_ids)) " +
 	"	join nc_delivery_info di on (di.message_id = m.id ) " +
 	"where notify_after_processing = true " +
-	"group by 1,2,3,4,5,6,7,8 " +
-	"having max(di.processed_on) < NOW() - make_interval(secs  => :secondsSinceLastProcessing)") 
-    List<GenericEvent> findEventsForSummaryNotification(@Param("secondsSinceLastProcessing") int secondsSinceLastProcessing);								 
-
+	"group by 1,2,3,4,5,6,7,8,9,10 " +
+	"having max(di.processed_on) < NOW() - make_interval(secs  => :secondsSinceLastProcessing) " +
+	"and min(di.processed_on) > :timestamp")
+    List<GenericEvent> findEventsForSummaryNotification(@Param("secondsSinceLastProcessing") int secondsSinceLastProcessing,
+														@Param("timestamp") Instant timestamp);
 }

--- a/src/main/java/com/obj/nc/repositories/GenericEventRepository.java
+++ b/src/main/java/com/obj/nc/repositories/GenericEventRepository.java
@@ -143,8 +143,6 @@ public interface GenericEventRepository extends PagingAndSortingRepository<Gener
 	"	join nc_delivery_info di on (di.message_id = m.id ) " +
 	"where notify_after_processing = true " +
 	"group by 1,2,3,4,5,6,7,8,9,10 " +
-	"having max(di.processed_on) < NOW() - make_interval(secs  => :secondsSinceLastProcessing) " +
-	"and min(di.processed_on) > :timestamp")
-    List<GenericEvent> findEventsForSummaryNotification(@Param("secondsSinceLastProcessing") int secondsSinceLastProcessing,
-														@Param("timestamp") Instant timestamp);
+	"having max(di.processed_on) < :timestamp")
+    List<GenericEvent> findEventsForSummaryNotification(@Param("timestamp") Instant timestamp);
 }

--- a/src/main/java/com/obj/nc/repositories/GenericEventRepository.java
+++ b/src/main/java/com/obj/nc/repositories/GenericEventRepository.java
@@ -88,11 +88,12 @@ public interface GenericEventRepository extends PagingAndSortingRepository<Gener
 	@Query(
 		value =
 			"with latest_msg_di as (\n" +
-			"    select di.message_id as message_id, di.status, MAX(di.processed_on) as processed_on\n" +
-			"    from nc_delivery_info di\n" +
-			"    join nc_message m on di.message_id = m.id\n" +
+			"    select distinct on (di.message_id)\n" +
+			"        di.message_id as message_id,\n" +
+			"        di.status as status\n" +
+			"    from nc_delivery_info di join nc_message m on di.message_id = m.id\n" +
 			"    where di.status != 'PROCESSING'\n" +
-			"    GROUP BY di.message_id, di.status\n" +
+			"    order by di.message_id, di.processed_on desc\n" +
 			")\n" +
 			"select msg_with_endp.endpoint_type,\n" +
 			"       count(msg_with_endp.message_id)                                    as messages_count,\n" +
@@ -106,12 +107,12 @@ public interface GenericEventRepository extends PagingAndSortingRepository<Gener
 			"       count(di.message_id) filter (where di.status = 'DELIVERY_FAILED')  as messages_delivery_failed_count,\n" +
 			"       count(di.message_id) filter (where di.status = 'DISCARDED')        as messages_discarded_count\n" +
 			"from nc_event e\n" +
-			"    left join (select msg.*, m2e.message_id as message_id, m2e.endpoint_id as endpoint_id, ep.endpoint_type\n" +
-			"        from nc_message msg\n" +
-			"            inner join nc_message_2_endpoint_rel m2e on (m2e.message_id = msg.id)\n" +
-			"            inner join nc_endpoint ep on ep.id = m2e.endpoint_id) msg_with_endp\n" +
-			"        on (e.id = any (msg_with_endp.previous_event_ids))\n" +
-			"    left join latest_msg_di di on di.message_id = msg_with_endp.id\n" +
+			"         left join (select msg.*, m2e.message_id as message_id, m2e.endpoint_id as endpoint_id, ep.endpoint_type\n" +
+			"                    from nc_message msg\n" +
+			"                             inner join nc_message_2_endpoint_rel m2e on (m2e.message_id = msg.id)\n" +
+			"                             inner join nc_endpoint ep on ep.id = m2e.endpoint_id) msg_with_endp\n" +
+			"                   on (e.id = any (msg_with_endp.previous_event_ids))\n" +
+			"         left join latest_msg_di di on di.message_id = msg_with_endp.id\n" +
 			"where e.id = (:eventId)::uuid\n" +
 			"  and message_class NOT LIKE '%Templated'\n" +
 			"group by msg_with_endp.endpoint_type",
@@ -137,18 +138,20 @@ public interface GenericEventRepository extends PagingAndSortingRepository<Gener
 	@Query(
 		"select e.id,e.flow_id,e.external_id, e.payload_json,e.time_created,e.time_consumed, e.payload_type, e.notify_after_processing, e.name, e.description\n" +
 		"from nc_event e\n" +
-		"    join nc_message m on (e.id  = ANY(m.previous_event_ids))\n" +
-		"    join nc_delivery_info di on (di.message_id = m.id )\n" +
+		"         join nc_message m on (e.id  = ANY(m.previous_event_ids))\n" +
+		"         join nc_delivery_info di on (di.message_id = m.id)\n" +
 		"where notify_after_processing = true\n" +
 		"group by 1,2,3,4,5,6,7,8,9,10\n" +
 		"having max(di.processed_on) < :timestamp\n" +
 		"union (\n" +
 		"    with latest_msg_di as (\n" +
-		"        select di.message_id as message_id, di.status, MAX(di.processed_on) as processed_on\n" +
-		"        from nc_delivery_info di\n" +
-		"                 join nc_message m on di.message_id = m.id\n" +
+		"        select distinct on (di.message_id)\n" +
+		"            di.message_id as message_id,\n" +
+		"            di.status as status,\n" +
+		"            di.processed_on as processed_on\n" +
+		"        from nc_delivery_info di join nc_message m on di.message_id = m.id\n" +
 		"        where di.status != 'PROCESSING'\n" +
-		"        GROUP BY di.message_id, di.status\n" +
+		"        order by di.message_id, di.processed_on desc\n" +
 		"    )\n" +
 		"    select e.id,e.flow_id,e.external_id, e.payload_json,e.time_created,e.time_consumed, e.payload_type, e.notify_after_processing, e.name, e.description\n" +
 		"    from nc_event e\n" +
@@ -157,7 +160,7 @@ public interface GenericEventRepository extends PagingAndSortingRepository<Gener
 		"    where notify_after_processing = true\n" +
 		"    group by 1,2,3,4,5,6,7,8,9,10\n" +
 		"    having max(di.processed_on) < NOW() - make_interval(secs  => :secondsSinceLastProcessing)\n" +
-			"and count(di.message_id) filter (where di.status != 'DELIVERY_PENDING') = count(di.message_id)\n" +
+		"       and count(di.message_id) filter (where di.status != 'DELIVERY_PENDING') = count(di.message_id)\n" +
 		")\n"
 	)
 	List<GenericEvent> findEventsForSummaryNotification(@Param("secondsSinceLastProcessing") int secondsSinceLastProcessing,

--- a/src/main/resources/nc-internal-resources/message-templates/event-summary.html
+++ b/src/main/resources/nc-internal-resources/message-templates/event-summary.html
@@ -38,7 +38,6 @@
 					<th th:text="#{emailSummary.header1.endpointType}"> # </th>
 					<th th:text="#{emailSummary.header1.messageCount}"> # </th>
 					<th th:text="#{emailSummary.header1.endpointsCount}"> endpoint # </th>
-					<th th:text="#{emailSummary.header1.messagesProcessingCount}"> processing # </th>
 					<th th:text="#{emailSummary.header1.messagesSentCount}"> send # </th>
 					<th th:text="#{emailSummary.header1.messagesFailedCount}"> failed # </th>
 					<th th:text="#{emailSummary.header1.messagesDiscardedCount}"> discarded # </th>
@@ -53,7 +52,6 @@
 					<td th:text="${stats.endpointType}"> </td>
 					<td th:text="${stats.messagesCount}"> </td>
 					<td th:text="${stats.endpointsCount}"> </td>
-					<td th:text="${stats.messagesProcessingCount}"> </td>
 					<td th:text="${stats.messagesSentCount}"> </td>
 					<td th:text="${stats.messagesFailedCount}"> </td>
 					<td th:text="${stats.messagesDiscardedCount}"> </td>

--- a/src/test/java/com/obj/nc/controllers/EventsRestControllerTest.java
+++ b/src/test/java/com/obj/nc/controllers/EventsRestControllerTest.java
@@ -631,7 +631,7 @@ class EventsRestControllerTest extends BaseIntegrationTest {
         findEventsForNotif(0);
 
         //WHEN
-        Get.getJdbc().update("update nc_delivery_info set processed_on = now() - INTERVAL '10 min'");
+        Get.getJdbc().update("update nc_delivery_info set processed_on = now() - INTERVAL '25 hours'");
 
         //THEN
         List<JsonNode> events = findEventsForNotif(1);

--- a/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationTest.java
+++ b/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationTest.java
@@ -86,7 +86,7 @@ class EventSummaryNotificationTest extends BaseIntegrationTest {
         testEvent.setNotifyAfterProcessing(true);
         eventRepo.save(testEvent);
 
-        springJdbcTemplate.update("update nc_delivery_info set processed_on = now() - INTERVAL '1 min'");
+        springJdbcTemplate.update("update nc_delivery_info set processed_on = now() - INTERVAL '25 hours'");
 
         //then
         boolean received = greenMail.waitForIncomingEmail(15000L, 1);   //this test can take some time

--- a/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationTest.java
+++ b/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationTest.java
@@ -107,7 +107,7 @@ class EventSummaryNotificationTest extends BaseIntegrationTest {
                 "EMAIL", "SMS",
                 "0", "1", "2",
                 "Message type", "Messages produced", "Number of recipients",
-                "NC Processing", "NC Sent", "NC Failed", "NC Discarded", "Delivered",
+                "NC Sent", "NC Failed", "NC Discarded", "Delivered",
                 "Delivery Failed", "Delivery Unknown", "Delivery Pending"
             )
         );

--- a/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationWithAdditionalRecipientShouldFailTest.java
+++ b/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationWithAdditionalRecipientShouldFailTest.java
@@ -76,7 +76,7 @@ class EventSummaryNotificationWithAdditionalRecipientShouldFailTest extends Base
         GenericEvent testEvent = testDataController.persistFullEventProcessingData();
         testEvent.setNotifyAfterProcessing(true);
         eventRepo.save(testEvent);
-        springJdbcTemplate.update("update nc_delivery_info set processed_on = now() - INTERVAL '1 min'");
+        springJdbcTemplate.update("update nc_delivery_info set processed_on = now() - INTERVAL '25 hours'");
 
         //then
         boolean received = greenMail.waitForIncomingEmail(15000L, 3);   //this test can take some time

--- a/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationWithAdditionalRecipientShouldPassTest.java
+++ b/src/test/java/com/obj/nc/flows/eventSummaryNotification/EventSummaryNotificationWithAdditionalRecipientShouldPassTest.java
@@ -76,7 +76,7 @@ class EventSummaryNotificationWithAdditionalRecipientShouldPassTest extends Base
         GenericEvent testEvent = testDataController.persistFullEventProcessingData();
         testEvent.setNotifyAfterProcessing(true);
         eventRepo.save(testEvent);
-        springJdbcTemplate.update("update nc_delivery_info set processed_on = now() - INTERVAL '1 min'");
+        springJdbcTemplate.update("update nc_delivery_info set processed_on = now() - INTERVAL '25 hours'");
 
         //then
         boolean received = greenMail.waitForIncomingEmail(15000L, 2);   //this test can take some time

--- a/src/test/java/com/obj/nc/repositories/GenericEventRepositoryTest.java
+++ b/src/test/java/com/obj/nc/repositories/GenericEventRepositoryTest.java
@@ -93,7 +93,7 @@ public class GenericEventRepositoryTest extends BaseIntegrationTest {
 
 		int secondsSinceLastProcessing = 60;
 		Instant now = LocalDateTime.now().toInstant(ZoneOffset.ofTotalSeconds(0));
-		Instant period = now.minus(1, ChronoUnit.DAYS);
+		Instant period = now.minus(2, ChronoUnit.DAYS);
 
 		List<GenericEvent> events = eventRepository.findEventsForSummaryNotification(secondsSinceLastProcessing, period);
 		Assertions.assertThat(events).hasSize(1);
@@ -125,7 +125,7 @@ public class GenericEventRepositoryTest extends BaseIntegrationTest {
 		DeliveryInfo deliveryInfo = DeliveryInfo.builder()
 				.endpointId(endpoint.get(0).getId())
 				.messageId(message.getId())
-				.status(DELIVERY_PENDING)
+				.status(status)
 				.id(UUID.randomUUID())
 				.build();
 		deliveryInfoRepo.save(deliveryInfo);

--- a/src/test/java/com/obj/nc/repositories/GenericEventRepositoryTest.java
+++ b/src/test/java/com/obj/nc/repositories/GenericEventRepositoryTest.java
@@ -78,22 +78,20 @@ public class GenericEventRepositoryTest extends BaseIntegrationTest {
 	public void testShouldFindOneEventForSummaryNotification() {
 		persistEventWithDeliveryInfoProcessedOneDayAgo();
 
-		int secondsSinceLastProcessing = 60;
 		Instant now = LocalDateTime.now().toInstant(ZoneOffset.ofTotalSeconds(0));
-		Instant period = now.minus(2, ChronoUnit.DAYS);
-
-		List<GenericEvent> events = eventRepository.findEventsForSummaryNotification(secondsSinceLastProcessing, period);
-		Assertions.assertThat(events).size().isEqualTo(1);
+		Instant period = now.minus(1, ChronoUnit.DAYS);
+		List<GenericEvent> events = eventRepository.findEventsForSummaryNotification(period);
+		Assertions.assertThat(events).hasSize(1);
 	}
 
 	@Test
 	public void testShouldNotFindAnyEventForSummaryNotification() {
 		persistEventWithDeliveryInfoProcessedOneDayAgo();
 
-		int secondsSinceLastProcessing = 60;
 		Instant now = LocalDateTime.now().toInstant(ZoneOffset.ofTotalSeconds(0));
-		Instant period = now.minus(1, ChronoUnit.DAYS);
-		List<GenericEvent> events = eventRepository.findEventsForSummaryNotification(secondsSinceLastProcessing, period);
+		Instant period = now.minus(2, ChronoUnit.DAYS);
+
+		List<GenericEvent> events = eventRepository.findEventsForSummaryNotification(period);
 		Assertions.assertThat(events).isEmpty();
 	}
 
@@ -116,7 +114,7 @@ public class GenericEventRepositoryTest extends BaseIntegrationTest {
 				.build();
 		deliveryInfoRepo.save(deliveryInfo);
 
-		Get.getJdbc().update("update nc_delivery_info set processed_on = now() - INTERVAL '1 day'");
+		Get.getJdbc().update("update nc_delivery_info set processed_on = now() - INTERVAL '30 hours'");
 	}
 
 	public static GenericEvent createProcessedEvent() {

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -41,6 +41,8 @@ nc.functions.json-schema-validator.payload-type-json-schema-name.BLOG=koderia-bl
 
 nc.flows.test-mode.enabled=false
 nc.flows.email-processing.multi-locales-merge-strategy=MERGE
+nc.flows.delivery-status-tracking.max-age-of-unfinished-deliveries-in-days=1
+
 spring.datasource.platform=postgres
 spring.datasource.url=jdbc:postgresql://localhost:25432/nc
 spring.datasource.username=nc
@@ -52,6 +54,7 @@ spring.mail.password=xxx
 spring.main.allow-bean-definition-overriding=true
 spring.datasource.hikari.minimum-idle=5
 spring.datasource.hikari.maximum-pool-size=2
+
 #---
 spring.config.activate.on-profile=bitbucket
 logging.level.org.springframework=INFO


### PR DESCRIPTION
tento PR suvisi s PR na osk-flows: https://bitbucket.org/obj-team/osk-flows/pull-requests/27

![Screenshot from 2023-10-29 22-31-21](https://github.com/com-obj/notiflow/assets/89594571/15b78201-52e3-4af9-a707-83682d1de2a5)
- pocty nesedeli, pretoze sme sumarny email posielali cca minutu po tom, ako sme vytvorili spravy, teda prilis skoro, kedze posielanie moze trvat minuty, hodiny, az dni, osetrene to mame teraz tak, ze sumar posleme:
    1. pouzivame property "nc.flows.event-summary-notif.seconds-since-last-processing" - ak uplynulo uz aspon tolkoto sekund od vytvorenia sprav a kazda sprava uz ma nejaky stav ktory nie je pending, tak je spracovanie sprav hotove a mozme poslat sumar (porovnavame iba najcerstvejsi stav spravy)
    - tu moze nastat este jedna situacia, ze vsetky spravy budu v stave SENT (este sme sa nestihli opytat gapu na stav) a vtedy posleme sumar, toto je tak kvoli tomu, ze ked budeme chciet trackovat emaily, tak tie taketo statistiky mozu mat, nepytame sa totiz externeho systemu na stav a teda dalej sa ich stav nebude menit, ak by sa nam to stalo, mozme vyriesit zvysenim sekund "nc.flows.event-summary-notif.seconds-since-last-processing" na hodnotu kedy sme sa uz gapu urcite aspon raz opytali na stav, tj. vacsiu ako property "nc.flows.delivery-status-tracking.poll-interval-in-seconds",..hmm toto rovno takto nastavim na testovacku
    
    2. pouzivame property "nc.flows.delivery-status-tracking.max-age-of-unfinished-deliveries-in-days", tj po kolkych dnoch sa prestaneme dopytovat gapu na stav spravy - ak uz uplynula tato doba od vytvorenia sprav a stale su nejake spravy v stace pending mame zarucene, ze uz sa stav sprav nezmeni, tj. mozme poslat sumar (porovnavame iba najcerstvejsi stav spravy)

pocty po fixe a vycisteni nahromadenych pending sedeli:
![image](https://github.com/com-obj/notiflow/assets/89594571/7b8c95f1-1dd1-4268-9779-5491ebf70cfd)


- do db insertneme stav message, iba ak sa zmenil, tj. 1.krat gap odpovie pending, tak zapiseme, 2.-3000.krat odpovie pending, tieto nezapiseme, 3001.krat odpovie nieco ine ako pending, tak zapiseme - DONE


tieto screenshoty znacia, ze nevracame duplicitne pending delivery infos (pocet 3688 - 1 delivery info prave pre 1 spravu):
![Screenshot from 2023-10-29 22-28-05](https://github.com/com-obj/notiflow/assets/89594571/14d470d7-25ea-4cb7-8036-f9d737a2bf4d)

![Screenshot from 2023-10-29 22-26-58](https://github.com/com-obj/notiflow/assets/89594571/da4fb828-1745-493c-b46d-a93a014de2c6)

- delete nad nahromadenymi pending stavmi - zmazeme vsetky ulozene odpovede z gapu per message, ktore su pending, okrem najstarsieho (to zodpoveda algoritmu zapisovania vyssie, kde prvy pending zapiseme, ale ostatne uz nie) - DONE, sqlko je na sia-test1 masine:
![image](https://github.com/com-obj/notiflow/assets/89594571/0a612c12-bd57-40c7-b22f-c37eac25b379)
